### PR TITLE
Remove unnecessary style at HbbTV

### DIFF
--- a/config/pagestrategy/hbbtv/body
+++ b/config/pagestrategy/hbbtv/body
@@ -1,4 +1,4 @@
-<object id="appmgr" type="application/oipfApplicationManager" style="width: 0px; height: 0px;"></object>
+<object id="appmgr" type="application/oipfApplicationManager"></object>
 <script type="text/javascript" language="javascript">
 //<![CDATA[
 	var app = document.getElementById('appmgr').getOwnerApplication(document);


### PR DESCRIPTION
Following the 7.2.1 Of OIPF speicification, 
The application/oipfApplicationManager is non-visual embedded object.
So no need to set size style.

TEST : run at LG TV 2011, 2012, 2013
