### PR TITLE
Bug fix and jshint improvements in styletopleft

### DIFF
--- a/static/script/devices/anim/styletopleft.js
+++ b/static/script/devices/anim/styletopleft.js
@@ -82,10 +82,21 @@ require.def(
 		}
         /* documented in antie.devices.Device */
 		Device.prototype.scrollElementTo = function(options) {
-			// Take a copy of the options object to avoid modifying the original. Need to do this rather than
+			// Helper function to return an object that inherits from the original
+			function inherit(original) {
+				function Inherited() {}
+				
+				Inherited.prototype = original;
+				return new Inherited();
+			}
+			
+			// Make a new modifiable options object inheriting from the original. Need to do this rather than
 			// simply reverting any changes before returning, as the tweening library calls onComplete() which
 			// may require an unchanged object.
-			var newOptions = {};
+			var newOptions = inherit(options);
+			if (options.to) {
+				newOptions.to = inherit(options.to);
+			}
 
 			// Check validity of call and use child element as the real target
 			if (new RegExp("_mask$").test(options.el.id)) {
@@ -99,23 +110,12 @@ require.def(
 				return null;
 			}
 			
-			// Now we know the call is valid, copy all other properties from options to newOptions.
-			for (p in options) {
-				// 'el' has already been handled, the 'to' property is specially handled below.
-				if(p !== 'to' && p !== 'el' && options.hasOwnProperty(p)) {
-					newOptions[p] = options[p];
-				}
-			}
-			
 			// Make a copy of the 'to' property, with the sign of the 'top' and 'left' properties flipped.
-			if (options.to) {
-				newOptions.to = {};
-				if (options.to.left !== undefined) {
-					newOptions.to.left = -options.to.left;
-				}
-				if (options.to.top !== undefined) {
-					newOptions.to.top = -options.to.top;
-				}
+			if (options.to && options.to.left) {
+				newOptions.to.left = -options.to.left;
+			}
+			if (options.to && options.to.top) {
+				newOptions.to.top = -options.to.top;
 			}
 
 			var startLeft = newOptions.el.style.left.replace(/px/, '') || 0;


### PR DESCRIPTION
Primarily to fix the accidental creation of a global variable 'p' in the 'for' loop. A better approach anyway is to use prototypical inheritance to avoid modifying the original object, rather than taking a deep copy.

Jshint's suggestions for the file have also been acted upon.
