### PR TITLE
RakeFile Cleanup

### DIFF
--- a/static/Rakefile
+++ b/static/Rakefile
@@ -95,7 +95,11 @@ end
 at_exit do
     if $dirty == true
         shutDown
-    end     
+    end
+    
+    if ($? && $?.exited?)
+      exit($?.exitstatus)
+   end     
 end
 
 #default - run the tests


### PR DESCRIPTION
Split rake file into fewer tasks which can be run independently
Config creation switched to file tasks (only run when file is not present) to allow manual override of config
