### PR TITLE
Add section on launching new apps. Additions to Exiting.

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -52,6 +52,7 @@
             <ul class="dropdown-menu">
               <li><a href="{{site.baseurl}}/other/storage.html">Storage</a></li>
               <li><a href="{{site.baseurl}}/other/exiting.html">Exiting</a></li>
+              <li><a href="{{site.baseurl}}/other/launching.html">Launching</a></li>
               <li><a href="{{site.baseurl}}/other/networking.html">Networking</a></li>
               <li><a href="{{site.baseurl}}/other/tal-projects.html">TAL Projects</a></li>
               <li><a href="{{site.baseurl}}/other/contributing.html">Contributing</a></li>

--- a/other/exiting.md
+++ b/other/exiting.md
@@ -4,14 +4,36 @@ title: Exiting an Application
 ---
 # Exiting an Application
 
-<p class="lead">The framework provides a method you may call to exit the application back to the location that launched your application.</p>
+<p class="lead">The framework has a method you may call to exit the application, or return to the TAL application that launched yours.</p>
 
-To exit the application, obtain a reference to the device, then call the function `exit()`:
+## Returning to a previous TAL application
+
+The framework is capable of launching new TAL applications and returning through them. It maintains a history stack automatically that's passed from application to application. For information on how to launch a new TAL application in a way that generates the history stack and provides other convenient functionality, see the page on [Launching](launching.html).
+
+To check whether the framework knows about a previous TAL application, obtain a reference to the current application and use:
 {% highlight javascript %}
-device.exit();
+application.hasHistory();
 {% endhighlight %}
 
-You can check to see if the device supports exiting by calling:
+The `hasHistory()` function returns `True` if there is at least one previous TAL application in the history stack.
+
+To return to the last application in the history, use the `back()` function on the current application:
+{% highlight javascript %}
+application.back();
+{% endhighlight %}
+
+It is safe to call `back()` even if there's no history. In this case, it will work the same as `exit()` (see below).
+
+## Exiting to broadcast or the widget page
+
+To exit the running application and return to the broadcast or widget page from which it was launched, use the `exit()` function on the current application.
+
+Obtain a reference to the current application, then call the function `exit()`:
+{% highlight javascript %}
+application.exit();
+{% endhighlight %}
+
+You can check to see if the device supports exiting by obtaining a reference to the device object, then calling:
 
 {% highlight javascript %}
 if(device.exit !== Device.prototype.exit) {

--- a/other/launching.md
+++ b/other/launching.md
@@ -1,0 +1,34 @@
+---
+layout: default
+title: Launching Other TAL Applications
+---
+# Launching Other TAL Applications
+
+<p class="lead">The framework can launch other TAL applications, preserving URL query parameters and maintaining a history stack.</p>
+
+To launch a new TAL application by URL, obtain a reference to the Application object, then call the function `launchAppByURL()`:
+{% highlight javascript %}
+application.launchAppByURL('http://www.example.com/talapp/');
+{% endhighlight %}
+
+It's also possible to pass additional query parameters to the new application. Query parameters passed to the existing application will be preserved and passed to the new application by default. To overwrite them with your query parameters instead,  pass `True` to `launchAppByURL()` as the optional fourth parameter.
+
+This example demonstrates how to relaunch the same application with an additional query parameter `mode` and a route in the new application:
+
+{% highlight javascript %}
+application.launchAppByURL(application.getCurrentAppURL(), {mode: 'test'}, ['main', 'favourites']);
+{% endhighlight %}
+
+History is automatically maintained and passed between TAL applications. For information on how to use it to navigate backwards, see the section on [exiting](exiting.html).
+
+## Gain access to existing query parameters
+
+Existing URL query parameters passed to the current application can be obtained as a JSON object by using `getCurrentAppURLParameters()`. For example:
+{% highlight javascript %}
+var params = application.getCurrentAppURLParameters();
+if (params.mode === 'test') {
+    ...
+}
+{% endhighlight %}
+
+Remember that by default, query parameters passed to `launchAppByURL()` are merged with existing ones, so there's no need to use `getCurrentAppURLParameters()` to do the merging explicitly.


### PR DESCRIPTION
launchAppFromURL(), getCurrentAppURL(), getCurrentAppURLParameters() API documented on a new page called Launching.
Back journey functionality documented on the Exiting page.
