### PR TITLE
Samsung Maple workaround for seeking in newly started video

### DIFF
--- a/static/script/devices/media/samsung_maple.js
+++ b/static/script/devices/media/samsung_maple.js
@@ -278,6 +278,7 @@ require.def(
                     var jumped = this.playerPlugin.JumpForward(offsetInSeconds);
                     // Jump forward appears not to work consistently in the initial moments of a video playback.
                     // if we are in the initial set up, lets try resuming instead
+                    // Samsung 2010 returns -1 for failure. Newer API returns false.
                     if ((!jumped || jumped < 0) && this.videoPlayerState.currentTime < 1) {
                         this.playerPlugin.Stop();
                         this._resetVideoSize();


### PR DESCRIPTION
Fix for older Samsung Maple devices refusing to seek in a video before they have started playing. Also fixes audio playback via Maple API.
