### PR TITLE
Fix for multiple blur/focus events up tree when attempting to focus curr...

### DIFF
--- a/static/script-tests/tests/widgets/container.js
+++ b/static/script-tests/tests/widgets/container.js
@@ -912,4 +912,42 @@
 
 	};
 
+    this.ContainerTest.prototype.testFocussingChildButtonDoesNotCauseBlurOnParentWhenParentAlreadyFocussed = function(queue) {
+        queuedApplicationInit(
+            queue,
+            "lib/mockapplication",
+            ["antie/widgets/container","antie/widgets/button"],
+            function(application, Container, Button) {
+                var root, container1, container2, button, handlerCalled;
+
+                queue.call('setup widget tree', function () {
+                    root = new Container("root");
+                    application.setRootWidget(root);
+                    container1 = new Container("container1");
+                    root.appendChildWidget(container1);
+                    container2 = new Container("container2");
+                    container1.appendChildWidget(container2);
+                    button = new Button('button');
+                    container2.appendChildWidget(button);
+                    button.focus();
+                    container2.addEventListener('blur', function (evt) {
+                        if (evt.target === container2) {
+                            handlerCalled = true;
+                        }
+                    });
+                    handlerCalled = false;
+                });
+
+                queue.call('Try second focus', function () {
+                    button.focus();
+                });
+
+                queue.call('assert handler not called', function () {
+                    assertFalse('Blur event fired on parent', handlerCalled);
+                })
+            }
+        );
+
+    };
+
 })();

--- a/static/script/widgets/container.js
+++ b/static/script/widgets/container.js
@@ -258,7 +258,7 @@ require.def('antie/widgets/container',
 					return false;
 				}
 				if(this.hasChildWidget(widget.id) && widget.isFocusable()) {
-					if(this._activeChildWidget) {
+					if(this._activeChildWidget && this._activeChildWidget !== widget) {
 						this._activeChildWidget.removeClass('active');
 						this._setActiveChildFocussed(false);
 					}


### PR DESCRIPTION
...ently focussed button

setActiveChildWidget has no check to see if the widget to be set active is the currently active child.
It calls _setActiveChildFocussed(false) which will cause the child to be blurred (if currently focussed).
Later in the method it calls _setActiveChildFocussed(true) which sets the child focussed once more (this will always happen as the previous _setActiveChildFocussed(false) ensured it was blurred)

This causes a nasty bug in conjunction with Button.focus(). focus() recursively works its way up the tree, calling setActiveChildWidget(childWidget) at each node. The above bug causes each currently focussed node higher in the tree to emit both a blur and a focus event as focus is removed and instantly set back. This can make using these events for their intended purpose tricky.
