### PR TITLE
Changes required to deploy TAL 1.4.6

### DIFF
--- a/config/pagestrategy/samsungmaple/body
+++ b/config/pagestrategy/samsungmaple/body
@@ -1,5 +1,6 @@
   <object id='playerPlugin' border='0' classid='clsid:SAMSUNG-INFOLINK-PLAYER' style='position: absolute'></object>
   <object id='audioPlugin' border='0' classid='clsid:SAMSUNG-INFOLINK-AUDIO' style='position: absolute'></object>
+  <object id='pluginObjectTV' border='0' classid='clsid:SAMSUNG-INFOLINK-TV' style='opacity:0.0; width:0px; height:0px;'></object>
   <object id='pluginObjectTVMW' border='0' classid='clsid:SAMSUNG-INFOLINK-TVMW' style='position: absolute'></object>
   <object id='pluginObjectNNavi' border='0' classid='clsid:SAMSUNG-INFOLINK-NNAVI' style='position: absolute'></object>
   <object id='pluginObjectWindow' border='0' classid='clsid:SAMSUNG-INFOLINK-WINDOW' style='visibility:hidden; position:absolute; opacity: 0.0; width: 0; height: 0'></object>

--- a/static/script-tests/tests/devices/broadcastsource/hbbtvsourcetest.js
+++ b/static/script-tests/tests/devices/broadcastsource/hbbtvsourcetest.js
@@ -50,6 +50,25 @@
         }, config);
     };
 
+
+    this.hbbtvSource.prototype.testCreateBroadcastSourceReturnsSingletonHBBTVObject = function(queue) {
+        expectAsserts(1);
+
+        var config = this.getGenericHBBTVConfig();
+        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/broadcastsource/hbbtvsource"], function(application, HbbTVSource) {
+            var device = application.getDevice();
+
+            var hbbtvConstructor = this.sandbox.spy(HbbTVSource.prototype, "init");
+
+            device.createBroadcastSource();
+            device.createBroadcastSource();
+            device.createBroadcastSource();
+
+            assertTrue('BroadcastSource should be an object', hbbtvConstructor.calledOnce);
+
+        }, config);
+    };
+
     this.hbbtvSource.prototype.testCreateBroadcastWhenHbbTvApiIsNotAvailableThrowsException = function(queue) {
         expectAsserts(1);
 

--- a/static/script-tests/tests/devices/broadcastsource/samsungtvsourcetest.js
+++ b/static/script-tests/tests/devices/broadcastsource/samsungtvsourcetest.js
@@ -50,6 +50,24 @@
         }, config);
     };
 
+    this.SamsungTvSource.prototype.testCreateBroadcastSourceReturnsSingletonSamsungSourceObject = function(queue) {
+        expectAsserts(1);
+
+        var config = this.getGenericSamsungBroadcastConfig();
+        queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/broadcastsource/samsungtvsource"], function(application, SamsungTVSource) {
+            var device = application.getDevice();
+
+            var samsungConstructor = this.sandbox.spy(SamsungTVSource.prototype, "init");
+
+            device.createBroadcastSource();
+            device.createBroadcastSource();
+            device.createBroadcastSource();
+
+            assertTrue('BroadcastSource should be an object', samsungConstructor.calledOnce);
+
+        }, config);
+    };
+
     this.SamsungTvSource.prototype.testCreateBroadcastWhenSamsungBroadcastApiIsNotAvailableThrowsException = function(queue) {
         expectAsserts(1);
 
@@ -191,7 +209,7 @@
         }, config);
     };
 
-    this.SamsungTvSource.prototype.testDestroyResetsTheScreenSettings= function(queue) {
+    this.SamsungTvSource.prototype.testDestroyResetsTheScreenSettings = function(queue) {
         expectAsserts(5);
 
         var config = this.getGenericSamsungBroadcastConfig();

--- a/static/script/devices/broadcastsource/hbbtvsource.js
+++ b/static/script/devices/broadcastsource/hbbtvsource.js
@@ -105,7 +105,16 @@ require.def('antie/devices/broadcastsource/hbbtvsource',
             },
             setChannel : function(params) {
                 var self = this;
-                var channelType = this._getChannelType();
+                var channelType;
+
+                // TODO: Clean this up
+                // Attempt to get the channel type of the current channel
+                // If this is not available, fall back to ID_DVB_T
+                try {
+                    channelType = this._getChannelType();
+                } catch(e) {
+                    channelType = ID_DVB_T;
+                }
                 var newChannel = this._broadcastVideoObject.createChannelObject(channelType, params.onid, params.tsid, params.sid);
                 if (newChannel === null) {
                     params.onError({
@@ -159,16 +168,13 @@ require.def('antie/devices/broadcastsource/hbbtvsource',
              * @Returns The type of identification for the channel, as indicated by one of the ID_* constants in the
              * HBBTV specification
              */
-            _getChannelType
-                :
-                function() {
-                    var channelType = this._broadcastVideoObject.currentChannel.idType;
-                    if (typeof channelType === "undefined") {
-                        channelType = ID_DVB_T;
-                    }
-                    return channelType;
+            _getChannelType : function() {
+                var channelType = this._broadcastVideoObject.currentChannel.idType;
+                if (typeof channelType === "undefined") {
+                    channelType = ID_DVB_T;
                 }
-            ,
+                return channelType;
+            },
             /**
              * Sets the size of the broadcast object to be the same as the required screen size identified by antie at
              * application start up.
@@ -177,16 +183,26 @@ require.def('antie/devices/broadcastsource/hbbtvsource',
                 var currentLayout = Application.getCurrentApplication().getLayout().requiredScreenSize;
                 this.setPosition(0, 0, currentLayout.width, currentLayout.height);
             }
-        })
-            ;
+        });
 
         Device.prototype.isBroadcastSourceSupported = function() {
             return this.getHistorian().hasBroadcastOrigin();
         };
 
+        /**
+         * Create a broadcastSource object on the Device to be
+         * accessed as a singleton to avoid the init being run
+         * multiple times
+         */
         Device.prototype.createBroadcastSource = function() {
-            return new HbbTVSource();
+            if (!this._broadcastSource) {
+                this._broadcastSource = new HbbTVSource();
+            }
+
+            return this._broadcastSource;
         };
+
+        // Return the HbbtvSource object for testing purposes
+        return HbbTVSource;
     }
-)
-    ;
+);

--- a/static/script/devices/broadcastsource/samsungtvsource.js
+++ b/static/script/devices/broadcastsource/samsungtvsource.js
@@ -187,7 +187,14 @@ require.def('antie/devices/broadcastsource/samsungtvsource',
          * @returns {Object} Device-specific implementation of antie.widgets.broadcastsource
          */
         Device.prototype.createBroadcastSource = function() {
-            return new SamsungSource();
+            if (!this._broadcastSource) {
+                this._broadcastSource = new SamsungSource();
+            }
+
+            return this._broadcastSource;
         };
+
+        // Return for testing purposes only
+        return SamsungSource;
     }
 );


### PR DESCRIPTION
Adding pluginObjectTV object to maple page strategy. This allows us to hook into the OnEvent API for detecting broadcast events.
Updating the createBroadcastSource to use a singleton object behind the scenes.
