### PR TITLE
Add keybooard specific button class

### DIFF
--- a/static/script/widgets/keyboard.js
+++ b/static/script/widgets/keyboard.js
@@ -215,6 +215,7 @@ require.def('antie/widgets/keyboard',
 						var button = new Button(this.id + '_' + letter + "_" + col + "_" + row);
 						button.setDataItem(letter);
 						button.addClass('key'+letter);
+						button.addClass('keyboardButton');
 						button.appendChildWidget(new Label(letter));
 
 						this._letterButtons[this._keys[keyIndexId]] = button;


### PR DESCRIPTION
Long running style calculations are causing sluggish animations on some devices. To style the keyboard component requires using .button a lot which matches a lot of items on the screen as a button is a commonly used base class for selectable items.

I have added a keyboard button specific class so that the keyboard can be styled without affecting the rest of the application.
