### PR TITLE
Tidied up component.js - application and require were listed in the requ...

### DIFF
--- a/static/script/widgets/component.js
+++ b/static/script/widgets/component.js
@@ -26,9 +26,7 @@
 
 require.def('antie/widgets/component',
 	[
-	 	'antie/widgets/container',
-	 	'require',
-	 	'antie/application'
+	 	'antie/widgets/container'
 	],
 	function(Container) {
 		/**


### PR DESCRIPTION
...ire.def, but not passed into this module or used within in. This may have also been causing certain circular dependency issues, such as those experienced by iPlayer in their unit tests.
