### PR TITLE
Carousel v2 keyhandlers should only respond to own align events

### DIFF
--- a/static/script-tests/tests/widgets/carousel/keyhandlers/activatefirsthandler.js
+++ b/static/script-tests/tests/widgets/carousel/keyhandlers/activatefirsthandler.js
@@ -89,4 +89,19 @@
             }
         );
     };
+
+    this.ActivateFirstHandlerTest.prototype.testHandlerRespondsOnlyToOwnCarouselEvents = function (queue) {
+        this.runTest(queue,
+            function (application, Handler, CarouselCore, WidgetStrip, Mask, Navigator, Aligner, KeyEvent, Container, BeforeAlignEvent) {
+                var carousel, beforeAlignEvent, targetIndex;
+                carousel = this.createCarouselAndAttachHandler(CarouselCore, Handler);
+                targetIndex = 1;
+                this.sandbox.spy(carousel, 'setActiveIndex');
+
+                beforeAlignEvent = new BeforeAlignEvent(null, targetIndex);
+                carousel.bubbleEvent(beforeAlignEvent);
+                assert(carousel.setActiveIndex.notCalled);
+            }
+        );
+    };
 }());

--- a/static/script-tests/tests/widgets/carousel/keyhandlers/alignfirsthandler.js
+++ b/static/script-tests/tests/widgets/carousel/keyhandlers/alignfirsthandler.js
@@ -89,4 +89,19 @@
             }
         );
     };
+
+    this.AlignFirstHandlerTest.prototype.testHandlerRespondsOnlyToOwnCarouselEvents = function (queue) {
+        this.runTest(queue,
+            function (application, Handler, CarouselCore, WidgetStrip, Mask, Navigator, Aligner, KeyEvent, Container, AfterAlignEvent) {
+                var carousel, afterAlignEvent, targetIndex;
+                carousel = this.createCarouselAndAttachHandler(CarouselCore, Handler);
+                targetIndex = 1;
+                this.sandbox.spy(carousel, 'setActiveIndex');
+
+                afterAlignEvent = new AfterAlignEvent(null, targetIndex);
+                carousel.bubbleEvent(afterAlignEvent);
+                assert(carousel.setActiveIndex.notCalled);
+            }
+        );
+    };
 }());

--- a/static/script/widgets/carousel/keyhandlers/activatefirsthandler.js
+++ b/static/script/widgets/carousel/keyhandlers/activatefirsthandler.js
@@ -38,7 +38,9 @@ require.def('antie/widgets/carousel/keyhandlers/activatefirsthandler',
             _addAlignmentListeners: function () {
                 var carousel = this._carousel;
                 carousel.addEventListener('beforealign', function (ev) {
-                    carousel.setActiveIndex(ev.alignedIndex);
+                    if (ev.target === carousel) {
+                        carousel.setActiveIndex(ev.alignedIndex);
+                    }
                 });
             }
         });

--- a/static/script/widgets/carousel/keyhandlers/alignfirsthandler.js
+++ b/static/script/widgets/carousel/keyhandlers/alignfirsthandler.js
@@ -38,7 +38,9 @@ require.def('antie/widgets/carousel/keyhandlers/alignfirsthandler',
             _addAlignmentListeners: function () {
                 var carousel = this._carousel;
                 carousel.addEventListener('afteralign', function (ev) {
-                    carousel.setActiveIndex(ev.alignedIndex);
+                    if (ev.target === carousel) {
+                        carousel.setActiveIndex(ev.alignedIndex);
+                    }
                 });
             }
         });


### PR DESCRIPTION
Carousel v2's keyhandlers use align events to set the active index of
the carousel, either before or after alignment has occurred. Event
propagation is not stopped, to allow client code to listen to them too.

But the keyhandlers do not check that the event has come from the
carousel to which they are attached. This means that if one carousel
is contained within another, the keyhandler of the parent is triggered
by alignment events from the child.

This commit fixes the bug by checking the source of each alignment event.
It also adds one test for each keyhandler which expose the original bug.
