### PR TITLE
Remove unused variable held on the base class

### DIFF
--- a/static/script/class.js
+++ b/static/script/class.js
@@ -18,7 +18,7 @@ require.def('antie/class', function() {
 	 * @abstract
 	 */
 	var Class = function(){};
- 
+
 	/**
 	 * Create a new Class that inherits from this class
 	 * @name extend
@@ -29,13 +29,13 @@ require.def('antie/class', function() {
 	 */
 	Class.extend = function(prop) {
 		var _super = this.prototype;
-	 
+
 		// Instantiate a base class (but only create the instance,
 		// don't run the init constructor)
 		initializing = true;
 		var prototype = new this();
 		initializing = false;
-	 
+
 		// Copy the properties over onto the new prototype
 		for (var name in prop) {
 			// Check if we're overwriting an existing function
@@ -44,40 +44,38 @@ require.def('antie/class', function() {
 				(function(name, fn){
 					return function() {
 						var tmp = this._super;
-					 
+
 						// Add a new ._super() method that is the same method
 						// but on the super-class
 						this._super = _super[name];
-					 
+
 						// The method only need to be bound temporarily, so we
 						// remove it when we're done executing
-						var ret = fn.apply(this, arguments);       
+						var ret = fn.apply(this, arguments);
 						this._super = tmp;
-					 
+
 						return ret;
 					};
 				})(name, prop[name]) :
 				prop[name];
 		}
-	 
+
 		// The dummy class constructor
 		function Class() {
-			this.self = this;
-
 			// All construction is actually done in the init method
 			if ( !initializing && this.init )
 				this.init.apply(this, arguments);
 		}
-	 
+
 		// Populate our constructed prototype object
 		Class.prototype = prototype;
-	 
+
 		// Enforce the constructor to be what we expect
 		Class.constructor = Class;
 
 		// And make this class extendable
 		Class.extend = arguments.callee;
-	 
+
 		return Class;
 	};
 


### PR DESCRIPTION
Remove unused variable from base class. Saving of `self` on the base class is not in the original class.js definition: http://ejohn.org/blog/simple-javascript-inheritance/

Additionally this pollutes the Chrome memory output quite seriously making it harder to track down memory leaks.

This does not affect a large TAL application although this has only been tested on my local development machine.
