### PR TITLE
Fix the use of the HR tag for onscreen logging on HBBTV devices.

### DIFF
--- a/static/script/devices/logging/onscreen.js
+++ b/static/script/devices/logging/onscreen.js
@@ -56,7 +56,7 @@ require.def(
 			if(logItems.length > 10) {
 				logItems.shift();
 			}
-			div.innerHTML = logItems.join("<hr noshade />");
+			div.innerHTML = logItems.join("<hr class='__onScreenLoggingBreak' />");
 		}
 		var loggingMethods = {
 			/**


### PR DESCRIPTION
It has been observed in Australia that some devices will not display the onscreen logging messages. This is due to the use of 'noshade' in the HR tag.

Use the CSS class '__onScreenLoggingBreak' to change the look of the HR tag instead of using 'noshade'.
