### PR TITLE
To work-around a bug in webkit (https://bugs.webkit.org/show_bug.cgi?id=...

### DIFF
--- a/config/pagestrategy/hbbtv/body
+++ b/config/pagestrategy/hbbtv/body
@@ -1,4 +1,4 @@
-<object id="appmgr" type="application/oipfApplicationManager" style="width: 0px; height: 0px; display: none;"></object>
+<object id="appmgr" type="application/oipfApplicationManager" style="width: 0px; height: 0px; visibility:hidden;"></object>
 <script type="text/javascript" language="javascript">
 //<![CDATA[
 	var appMgr = document.getElementById('appmgr');
@@ -8,4 +8,4 @@
 //]]>
 </script>
 
-<object id="broadcastVideoObject" type="video/broadcast" style="position: absolute; display: none;"></object>
+<object id="broadcastVideoObject" type="video/broadcast" style="position: absolute; width: 0px; height: 0px; visibility:hidden;"></object>


### PR DESCRIPTION
...68072), set the null dimensions and visibility hidden, instead of using display:none
