### PR TITLE
Update lg 2012 midrange config to use netcase exit strategy

### DIFF
--- a/config/devices/lg-tv_2012_midrange-default.json
+++ b/config/devices/lg-tv_2012_midrange-default.json
@@ -11,7 +11,7 @@
       "antie/devices/logging/onscreen",
       "antie/devices/logging/xhr",
       "antie/devices/logging/jstestdriver",
-      "antie/devices/exit/history"
+      "antie/devices/exit/netcast"
     ]
   },
   "logging": {


### PR DESCRIPTION
It was originally in the ticket IPLAYERTVV1-1547, but the config for LG doesn't seem to have changed (BTW, the panasonic is spot on)
