### PR TITLE
Samsung D8000 crashes on exit press due to hide event. Condition added so unload event can be used

### DIFF
--- a/static/script/devices/media/samsung_maple.js
+++ b/static/script/devices/media/samsung_maple.js
@@ -42,6 +42,7 @@ require.def(
         function invertAudioLevelCorrection(x) {
             return x / 40.0;
         }
+
         var SamsungPlayer = MediaInterface.extend({
             init: function(id, mediaType, eventHandlingCallback) {
                 this._super(id);
@@ -55,11 +56,7 @@ require.def(
 
                 this.mediaSource = null;
 
-                var self = this;
-                window.addEventListener('hide', function () {
-                    self.playerPlugin.Stop();
-                    self.tvmwPlugin.SetSource(self.originalSource);
-                }, false);
+                this._addExitStrategyEventListener();
 
                 if (mediaType == "audio") {
                     this._mediaType = "audio";
@@ -399,6 +396,14 @@ require.def(
                     var dimensions = Application.getCurrentApplication().getDevice().getScreenSize();
                     this.setWindow(0, 0, dimensions.width, dimensions.height);
                 }
+            },
+
+            _addExitStrategyEventListener: function() {
+              var self = this;
+              window.addEventListener('hide', function () {
+                self.playerPlugin.Stop();
+                self.tvmwPlugin.SetSource(self.originalSource);
+              }, false);
             }
         });
 

--- a/static/script/devices/media/samsung_maple_unload.js
+++ b/static/script/devices/media/samsung_maple_unload.js
@@ -1,0 +1,17 @@
+require.def('antie/devices/media/samsung_maple_unload',
+    [
+      'antie/devices/media/samsung_maple'
+    ],
+    function(SamsungMaple) {
+
+      return SamsungMaple.extend({
+        addExitStrategyEventListener: function() {
+          var self = this;
+          window.addEventListener('unload', function () {
+            self.playerPlugin.Stop();
+            self.tvmwPlugin.SetSource(self.originalSource);
+          }, false);
+        }
+      });
+    }
+);


### PR DESCRIPTION
samsung_d8000_unload can now be used for older samsung TV models
