### PR TITLE
Resolve some devices wont support setProperty problem

### DIFF
--- a/static/script/devices/anim/noanim.js
+++ b/static/script/devices/anim/noanim.js
@@ -132,7 +132,7 @@ require.def(
 
             for (i = 0; i !== properties.length; i += 1){
                 prop = properties[i];
-                elStyle.setProperty(prop, transEndPoints.getPropertyDestination(prop), '');
+                elStyle[prop] =  transEndPoints.getPropertyDestination(prop);
             }
             if (typeof options.onComplete === "function") {
                 options.onComplete();


### PR DESCRIPTION
This is an issue specific to Samsung Internet TV Maple 5, therefore, I change the way property is set.

It would be brilliant if this can go into 1.5.2.

Ta 
