### PR TITLE
Make sure outputElment exists in media widget after render is called

### DIFF
--- a/static/script-tests/tests/widgets/media.js
+++ b/static/script-tests/tests/widgets/media.js
@@ -158,7 +158,7 @@
     };
 
     this.MediaTest.prototype.testRenderReturnsResultFromMediaInterface = function (queue) {
-        expectAsserts(1);
+        expectAsserts(2);
         queuedApplicationInit(queue, 'lib/mockapplication', ["antie/devices/device", "antie/widgets/media", "antie/devices/media/mediainterface"], function(application, Device, Media, MediaInterface) {
 
 
@@ -173,6 +173,7 @@
 
             var result = media.render(Device);
 
+	        assertSame(media.outputElement, result);
             assertSame(object, result);
 
         });

--- a/static/script/widgets/media.js
+++ b/static/script/widgets/media.js
@@ -71,7 +71,8 @@ require.def('antie/widgets/media',
 				this.addClass('media');
 			},
             render: function(device) {
-                return this._mediaInterface.render(device);
+	            this.outputElement = this._mediaInterface.render(device);
+	            return this.outputElement;
             },
             show: function(options) {
                 this._mediaInterface.show(options);


### PR DESCRIPTION
This is to address the problem in insertChildWidget in container.js.

When widget 'render' method is called, it doesn't set outputElement, and the following 'insert' will fail on trying to insert a null object.
