### PR TITLE
Updated @link content to not be potentially encoded.

### DIFF
--- a/static/script-tests/tests/devices/browserdevice.js
+++ b/static/script-tests/tests/devices/browserdevice.js
@@ -223,7 +223,7 @@
             device.loadStyleSheet("/test/script-tests/fixtures/dynamicstylesheet.css", callback);
 
             assert(createElementStub.calledTwice);
-            assertEquals('@import url("/test/script-tests/fixtures/dynamicstylesheet.css");', createElementStub.returnValues[1].innerHTML);
+            assertEquals("@import url('/test/script-tests/fixtures/dynamicstylesheet.css');", createElementStub.returnValues[1].innerHTML);
             assert(appendToHead.calledWith(createElementStub.returnValues[1]));
        });
     };

--- a/static/script/devices/browserdevice.js
+++ b/static/script/devices/browserdevice.js
@@ -191,7 +191,7 @@ require.def("antie/devices/browserdevice",
                 if (callback && supportsCssRules()) {
                     var style = this._createElement("style");
                     style.type = "text/css";
-                    style.innerHTML = '@import url("' + url + '");';
+                    style.innerHTML = "@import url('" + url + "');";
                     style.className = "added-by-antie";
                     document.getElementsByTagName("head")[0].appendChild(style);
 


### PR DESCRIPTION
This change allows better compatibility with MS browsers. In some cases `"x://blah/place/&quot/libs/css/stylesheet.css&quot"` would be attempted to be loaded. This change fixes it.
