### PR TITLE
Changing one of the widget strip tests to use objects instead of strings...

### DIFF
--- a/static/script-tests/tests/widgets/carousel/strips/widgetstrip.js
+++ b/static/script-tests/tests/widgets/carousel/strips/widgetstrip.js
@@ -514,7 +514,7 @@
                 self.sandbox.stub(device);
                 device.getElementOffset.returns({left: 40, top: 40});
                 strip = new WidgetStrip('strip', horizontalOrientation);
-                strip.getChildWidgets = self.sandbox.stub().returns(["widget1", "widget2"]);
+                strip.getChildWidgets = self.sandbox.stub().returns([{widget: "widget1"}, {widget: "widget2"}]);
                 strip.append(new Button(), 30);
                 strip.append(new Button(), 40);
                 strip.remove(strip.widgets()[1]);


### PR DESCRIPTION
... for its fake widgets. This was causing failiures in Chrome because the parentWidget property of a string is read-only. This appears to only be a problem in recent versions of Chrome
