### PR TITLE
Modify behaviour of enter buffering sentinel

### DIFF
--- a/static/script-tests/tests/devices/mediaplayer/html5commontests.js
+++ b/static/script-tests/tests/devices/mediaplayer/html5commontests.js
@@ -980,7 +980,7 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
     };
 
     // Sentinels
-    mixins.testEnterBufferingSentinelCausesTransitionToBufferingWhenPlaybackHaltsOutsideTimeToleranceOfStateChanged = function(queue) {
+    mixins.testEnterBufferingSentinelCausesTransitionToBufferingWhenPlaybackHaltsForMoreThanOneSentinelIterationSinceStateChanged = function(queue) {
         expectAsserts(3);
         var self = this;
         runMediaPlayerTest(this, queue, function (MediaPlayer) {
@@ -998,7 +998,7 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
         });
     };
 
-    mixins.testEnterBufferingSentinelDoesNotActivateWhenPlaybackHaltsWithinTimeToleranceOfStateChanged = function(queue) {
+    mixins.testEnterBufferingSentinelDoesNotActivateWhenPlaybackHaltsWhenOnlyOneSentinelIterationSinceStateChanged = function(queue) {
         expectAsserts(1);
         var self = this;
         runMediaPlayerTest(this, queue, function (MediaPlayer) {
@@ -1006,7 +1006,6 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
             advancePlayTime(self);
 
             clearEvents(self);
-            fireSentinels(self);
             fireSentinels(self);
 
             assertNoEvents(self);
@@ -1470,7 +1469,7 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
     };
 
     mixins.testSeekSentinelEmitsFailureEventAndGivesUpOnThirdAttemptWhenDeviceDoesNotEnterBufferingUponSeek = function(queue) {
-        expectAsserts(4);
+        expectAsserts(5);
         var self = this;
         runMediaPlayerTest(this, queue, function (MediaPlayer) {
             getToPlaying(self, MediaPlayer, 50);
@@ -1489,7 +1488,8 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
 
             resetStubsThenAdvanceTimeThenRunSentinels(self);
 
-            assertNoEvents(self);
+            assertNoEvent(self, MediaPlayer.EVENT.SENTINEL_SEEK);
+            assertNoEvent(self, MediaPlayer.EVENT.SENTINEL_SEEK_FAILURE);
             assertEquals(2, stubCreateElementResults.video.currentTime);
         });
     };

--- a/static/script/devices/mediaplayer/html5.js
+++ b/static/script/devices/mediaplayer/html5.js
@@ -518,9 +518,8 @@ require.def(
             },
 
             _enterBufferingSentinel: function() {
-                var TIME_TOLERANCE_SECS = 2;
-                var sentinelSetOutsideOfTolerance = this._lastSentinelTime - this._sentinelSetTime >= TIME_TOLERANCE_SECS;
-                if(!this._hasSentinelTimeAdvanced && !this._nearEndOfMedia && sentinelSetOutsideOfTolerance) {
+                var notFirstSentinelActivationSinceStateChange = this._sentinelIntervalNumber > 1;
+                if(!this._hasSentinelTimeAdvanced && !this._nearEndOfMedia && notFirstSentinelActivationSinceStateChange) {
                     this._emitEvent(MediaPlayer.EVENT.SENTINEL_ENTER_BUFFERING);
                     this._toBuffering();
                     return true;
@@ -605,9 +604,11 @@ require.def(
             _setSentinels: function(sentinels) {
                 var self = this;
                 this._clearSentinels();
+                this._sentinelIntervalNumber = 0;
                 this._sentinelSetTime = this.getCurrentTime();
                 this._lastSentinelTime = this.getCurrentTime();
                 this._sentinelInterval = setInterval(function() {
+                    self._sentinelIntervalNumber += 1;
                     var newTime = self.getCurrentTime();
                     self._hasSentinelTimeAdvanced = (newTime > self._lastSentinelTime + 0.2);
                     self._nearEndOfMedia = (self.getDuration() - (newTime || self._lastSentinelTime)) <= 1;


### PR DESCRIPTION
Sentinel enters buffering if the playback position hasn't changed
on the second activation of the sentinel, NOT after waiting for
playback position to have advanced from its original position by
2s.

This caters for the situation that a device exits buffering, but
hasn't actually buffered enough to play >2s of media. Without this
change, the media API would remain in the PLAYING state.
