### PR TITLE
Enable asynchronous behaviour during start up

### DIFF
--- a/static/script-tests/tests/application-initialisation.js
+++ b/static/script-tests/tests/application-initialisation.js
@@ -121,6 +121,8 @@
             var device = application.getDevice();
             application.destroy();
 
+            var clock = sinon.useFakeTimers();
+
             var deviceLoadStub = this.sandbox.stub(Device, "load");
 
             var runStub = this.sandbox.stub(MockApplication.prototype, "run");
@@ -146,8 +148,56 @@
 
             requireCallback(mockLayout);
 
+            clock.tick(1);
+
             assert(runStub.calledOnce);
-		});
+
+            clock.restore();
+                });
+	};
+	this.ApplicationInitialisationTest.prototype.testRunAsyncIsCalledAndTheProvidedCallbackInvokesRun = function(queue) {
+		expectAsserts(8);
+
+		queuedApplicationInit(queue, "lib/mockapplication", ["lib/mockapplication", "antie/devices/device"], function(application, MockApplication, Device) {
+
+            var device = application.getDevice();
+            application.destroy();
+
+            var deviceLoadStub = this.sandbox.stub(Device, "load");
+
+            var runAsyncStub = this.sandbox.stub(MockApplication.prototype, "runAsync");
+            var runStub = this.sandbox.stub(MockApplication.prototype, "run");
+
+            new MockApplication(document.createElement('div'), null, null, null); // jshint ignore:line
+
+            assert(deviceLoadStub.calledOnce);
+            var deviceLoadCallbacks = deviceLoadStub.args[0][1];
+            assertObject(deviceLoadCallbacks);
+            assertFunction(deviceLoadCallbacks.onSuccess);
+
+            var requireStub = this.sandbox.stub(window, "require");
+
+            deviceLoadCallbacks.onSuccess(device);
+
+            assert(requireStub.calledOnce);
+            var requireCallback = requireStub.args[0][1];
+            assertFunction(requireCallback);
+
+            assert(runAsyncStub.notCalled);
+
+            var mockLayout = { };
+
+            requireCallback(mockLayout);
+
+            assert(runAsyncStub.calledOnce);
+
+            var runAsyncCallback = runAsyncStub.args[0][0];
+
+            runAsyncCallback();
+                    
+            assert(runStub.calledOnce);
+
+           });
 	};
 	this.ApplicationInitialisationTest.prototype.testGetDevice = function(queue) {
 		expectAsserts(1);

--- a/static/script-tests/tests/application-routing.js
+++ b/static/script-tests/tests/application-routing.js
@@ -94,6 +94,8 @@
             var device = application.getDevice();
             application.destroy();
 
+            var clock = sinon.useFakeTimers();
+
             var deviceLoadStub = this.sandbox.stub(Device, "load");
 
             var routeStub = this.sandbox.stub(MockApplication.prototype, "route");
@@ -121,7 +123,11 @@
 
             requireCallback(mockLayout);
 
+            clock.tick(1);
+
             assert(routeStub.calledOnce);
+
+            clock.restore();
         });
 
 	};

--- a/static/script/application.js
+++ b/static/script/application.js
@@ -93,13 +93,24 @@ require.def('antie/application',
                         }
                     }
 
+                    var syncStartUp = function() {
+                        self.run();
+                        self.route(device.getCurrentRoute());
+                    };
+
                     require([_layout.module], function (layout) {
-                        self.setLayout(layout, styleBaseUrl, imageBaseUrl, _layout.css, _layout.classes, [], function () {
-                            self.run();
-                            self.route(device.getCurrentRoute());
+                        self.setLayout(layout, styleBaseUrl, imageBaseUrl, _layout.css, _layout.classes, [], function(){
+                            self.runAsync(syncStartUp);
                         });
                     });
                 }
+            },
+            /**
+             * Called once application startup is ready (i.e. config has been loaded).
+             * Override to apply any blocking start up work and then call the provided callback when done
+             */
+            runAsync: function (callback) {
+                setTimeout(callback(), 0);
             },
             /**
              * Called once application startup is ready (i.e. config has been loaded).

--- a/static/script/application.js
+++ b/static/script/application.js
@@ -110,7 +110,7 @@ require.def('antie/application',
              * Override to apply any blocking start up work and then call the provided callback when done
              */
             runAsync: function (callback) {
-                setTimeout(callback(), 0);
+                setTimeout(callback, 0);
             },
             /**
              * Called once application startup is ready (i.e. config has been loaded).


### PR DESCRIPTION
At present it is not possible to perform any asynchronous actions during start up of TAL applications as the run method is assumed to always be synchronous. 
- This prevents broadcast channel identification
- It prevents any client side behaviour occuring before the user is shown the application e.g. redirecting to a new domain

Split start up into two handles:
- runAsync which is provided a callback to invoke once any async behaviour is complete. The default behaviour if not overridden is to invoke the callback on the 'next' tick
- run which should implement any synchronous set up. default behaviour is the empty method.
