### PR TITLE
Return animation object on widget show/hide/moveTo

### DIFF
--- a/static/script-tests/tests/widgets/widget.js
+++ b/static/script-tests/tests/widgets/widget.js
@@ -340,7 +340,7 @@
     };
 
     this.WidgetTest.prototype.testShowCallsShowElementWithCorrectArgs = function(queue) {
-        expectAsserts(4);
+        expectAsserts(5);
 
         queuedApplicationInit(
             queue,
@@ -359,7 +359,7 @@
                 var afterAnimationCallback = function() {
                 };
 
-                widget.show({
+                var animation = widget.show({
                     fps: 25,
                     duration: 1000,
                     onComplete : afterAnimationCallback
@@ -369,6 +369,7 @@
                 assertEquals(25, spy.getCall(0).args[0].fps);
                 assertEquals(1000, spy.getCall(0).args[0].duration);
                 assertEquals(afterAnimationCallback, spy.getCall(0).args[0].onComplete);
+                assertNotUndefined(animation);
             }
         );
     };
@@ -421,7 +422,7 @@
     };
 
     this.WidgetTest.prototype.testHideCallsHideElementWithCorrectArgs = function(queue) {
-        expectAsserts(4);
+        expectAsserts(5);
 
         queuedApplicationInit(
             queue,
@@ -440,7 +441,7 @@
                 var afterAnimationCallback = function() {
                 };
 
-                widget.hide({
+                var animation = widget.hide({
                     fps: 25,
                     duration: 1000,
                     onComplete : afterAnimationCallback
@@ -450,6 +451,7 @@
                 assertEquals(25, spy.getCall(0).args[0].fps);
                 assertEquals(1000, spy.getCall(0).args[0].duration);
                 assertEquals(afterAnimationCallback, spy.getCall(0).args[0].onComplete);
+                assertNotUndefined(animation);
             }
         );
     };
@@ -508,7 +510,7 @@
     };
 
     this.WidgetTest.prototype.testMoveToCallsMoveElementToWithCorrectArgs = function(queue) {
-        expectAsserts(4);
+        expectAsserts(5);
 
         queuedApplicationInit(
             queue,
@@ -527,7 +529,7 @@
                 var afterAnimationCallback = function() {
                 };
 
-                widget.moveTo({
+                var animation = widget.moveTo({
                     to : {
                         top: 200,
                         left: 300
@@ -541,6 +543,7 @@
                 assertEquals(25, spy.getCall(0).args[0].fps);
                 assertEquals(1000, spy.getCall(0).args[0].duration);
                 assertEquals(afterAnimationCallback, spy.getCall(0).args[0].onComplete);
+                assertNotUndefined(animation);
             }
         );
     };

--- a/static/script/widgets/widget.js
+++ b/static/script/widgets/widget.js
@@ -290,13 +290,13 @@ define(
              * @param {Number}    [options.fps=25] Frames per second for fade animation.
              * @param {Number}    [options.duration=840] Duration of fade animation, in milliseconds (ms).
              * @param {String}    [options.easing=linear] Easing style for fade animation.
-             * @returns Boolean true if animation was called, otherwise false
+             * @returns The reference to the animation object when created.
              */
             show : function(options) {
                 if (this.outputElement) {
                     options.el = this.outputElement;
                     var device = this.getCurrentApplication().getDevice();
-                    device.showElement(options);
+                    return device.showElement(options);
                 } else {
                     throw new Error('Widget::show called - the current widget has not yet been rendered.');
                 }
@@ -309,13 +309,13 @@ define(
              * @param {Number}    [options.fps=25] Frames per second for fade animation.
              * @param {Number}    [options.duration=840] Duration of fade animation, in milliseconds (ms).
              * @param {String}    [options.easing=linear] Easing style for fade animation.
-             * @returns Boolean true if animation was called, otherwise false
+             * @returns The reference to the animation object when created.
              */
             hide : function(options) {
                 if (this.outputElement) {
                     options.el = this.outputElement;
                     var device = this.getCurrentApplication().getDevice();
-                    device.hideElement(options);
+                    return device.hideElement(options);
                 } else {
                     throw new Error('Widget::hide called - the current widget has not yet been rendered.');
                 }
@@ -328,13 +328,13 @@ define(
              * @param {Number}    [options.fps=25] Frames per second for fade animation.
              * @param {Number}    [options.duration=840] Duration of fade animation, in milliseconds (ms).
              * @param {String}    [options.easing=linear] Easing style for fade animation.
-             * @returns Boolean true if animation was called, otherwise false
+             * @returns The reference to the animation object when created.
              */
             moveTo : function(options) {
                 if (this.outputElement) {
                     options.el = this.outputElement;
                     var device = this.getCurrentApplication().getDevice();
-                    device.moveElementTo(options);
+                    return device.moveElementTo(options);
                 } else {
                     throw new Error('Widget::moveTo called - the current widget has not yet been rendered.');
                 }


### PR DESCRIPTION
This makes sure the created animation object gets returned from the `show` , `hide` and `moveTo` methods in `antie/widgets/widget`

As a small side note, these tests would fail when the test harness would receive `antie/devices/anim/noanim` as a modifier as that returns no object when calling these methods. I'm not sure on how to proceed regarding those and if you have any best-practices in place regarding this specific use-case? In my opinion the modifiers should be swappable without any changes, but it's also a bit weird to return objects in a place where that is not needed.
