### PR TITLE
*Spike* of animation handle approach

### DIFF
--- a/static/script-tests/tests/devices/anim/css3.js
+++ b/static/script-tests/tests/devices/anim/css3.js
@@ -121,17 +121,17 @@
     };
 
     this.CSS3AnimationTest.prototype.testScrollElementTo = function(queue) {
-        expectAsserts(2);
+        expectAsserts(3);
 
         var self = this;
         var config;
         config = getDefaultCssConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, inner;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, inner, animHandle;
             device = application.getDevice();
             inner = createScrollableDiv(self,device);
-            device.scrollElementTo({
+            animHandle = device.scrollElementTo({
                 el: self.div,
                 to: {
                     left: 100,
@@ -142,6 +142,7 @@
 
             assertEquals('-100px', inner.style.getPropertyValue('left'));
             assertEquals('-200px', inner.style.getPropertyValue('top'));
+            assertInstanceOf(AnimationHandle, animHandle);
         }, config);
     };
 
@@ -222,18 +223,18 @@
     };
 
     this.CSS3AnimationTest.prototype.testScrollElementToWithNoAnimCallsOnCompleteImmediately = function(queue) {
-        expectAsserts(1);
+        expectAsserts(2);
 
         var self = this;
         var config = getDefaultCssConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, onCompleteStub;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, onCompleteStub, animHandle;
             device = application.getDevice();
             createScrollableDiv(self,device);
             onCompleteStub = self.sandbox.stub();
 
-            device.scrollElementTo({
+            animHandle = device.scrollElementTo({
                 el: self.div,
                 to: {
                     left: 100,
@@ -242,25 +243,25 @@
                 skipAnim: true,
                 onComplete: onCompleteStub
             });
-
+            assertInstanceOf(AnimationHandle, animHandle);
             assertTrue(onCompleteStub.calledOnce);
         }, config);
     };
 
     this.CSS3AnimationTest.prototype.testScrollElementToWithNoAnimInConfigCallsOnCompleteImmediately = function(queue) {
-        expectAsserts(1);
+        expectAsserts(2);
 
         var self = this;
         var config = getDefaultCssConfig();
         config.animationDisabled = 'true';
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, onCompleteStub;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, onCompleteStub, animHandle;
             device = application.getDevice();
             createScrollableDiv(self,device);
             onCompleteStub = self.sandbox.stub();
 
-            device.scrollElementTo({
+            animHandle = device.scrollElementTo({
                 el: self.div,
                 to: {
                     left: 100,
@@ -268,7 +269,7 @@
                 },
                 onComplete: onCompleteStub
             });
-
+            assertInstanceOf(AnimationHandle, animHandle);
             assertTrue(onCompleteStub.calledOnce);
         }, config);
     };
@@ -357,17 +358,17 @@
     };
 
     this.CSS3AnimationTest.prototype.testMoveElementTo = function(queue) {
-        expectAsserts(2);
+        expectAsserts(3);
         var self = this;
 
         var config = getDefaultCssConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, div;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, div, animHandle;
             device = application.getDevice();
             div = createScrollableDiv(self,device);
 
-            device.moveElementTo({
+            animHandle = device.moveElementTo({
                 el: div,
                 to: {
                     left: 100,
@@ -375,7 +376,7 @@
                 },
                 skipAnim: false
             });
-
+            assertInstanceOf(AnimationHandle, animHandle);
             assertEquals('100px', div.style.getPropertyValue('left'));
             assertEquals('200px', div.style.getPropertyValue('top'));
         }, config);
@@ -384,18 +385,18 @@
     // TODO: need to test that moveElementTo() with skipAnim = false calls onComplete eventually
 
     this.CSS3AnimationTest.prototype.testMoveElementToWithAnimDoesNotCallOnCompleteImmediately = function(queue) {
-        expectAsserts(1);
+        expectAsserts(2);
 
         var self = this;
         var config = getDefaultCssConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, div, onCompleteStub;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, div, onCompleteStub, animHandle;
             device = application.getDevice();
             div = createScrollableDiv(self,device);
             onCompleteStub = self.sandbox.stub();
 
-            device.moveElementTo({
+            animHandle = device.moveElementTo({
                 el: div,
                 to: {
                     left: 100,
@@ -404,24 +405,24 @@
                 skipAnim: false,
                 onComplete: onCompleteStub
             });
-
+            assertInstanceOf(AnimationHandle, animHandle);
             assert(onCompleteStub.notCalled);
         }, config);
     };
 
     this.CSS3AnimationTest.prototype.testMoveElementToWithNoAnimCallsOnCompleteImmediately = function(queue) {
-        expectAsserts(1);
+        expectAsserts(2);
 
         var self = this;
         var config = getDefaultCssConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, div, onCompleteStub;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, div, onCompleteStub, animHandle;
             device = application.getDevice();
             div = createScrollableDiv(self,device);
             onCompleteStub = self.sandbox.stub();
 
-            device.moveElementTo({
+            animHandle = device.moveElementTo({
                 el: div,
                 to: {
                     left: 100,
@@ -430,25 +431,25 @@
                 skipAnim: true,
                 onComplete: onCompleteStub
             });
-
+            assertInstanceOf(AnimationHandle, animHandle);
             assert(onCompleteStub.calledOnce);
         }, config);
     };
 
     this.CSS3AnimationTest.prototype.testMoveElementToWithNoAnimInConfigCallsOnCompleteImmediately = function(queue) {
-        expectAsserts(1);
+        expectAsserts(2);
 
         var self = this;
         var config = getDefaultCssConfig();
         config.animationDisabled = 'true';
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, div, onCompleteStub;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, div, onCompleteStub, animHandle;
             device = application.getDevice();
             div = createScrollableDiv(self,device);
             onCompleteStub = self.sandbox.stub();
 
-            device.moveElementTo({
+            animHandle = device.moveElementTo({
                 el: div,
                 to: {
                     left: 100,
@@ -456,26 +457,26 @@
                 },
                 onComplete: onCompleteStub
             });
-
+            assertInstanceOf(AnimationHandle, animHandle);
             assert(onCompleteStub.calledOnce);
         }, config);
     };
 
     this.CSS3AnimationTest.prototype.testHideElement = function(queue) {
-        expectAsserts(2);
+        expectAsserts(3);
         var self = this;
 
         var config = getDefaultCssConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
             var device = application.getDevice();
             createScrollableDiv(self,device);
 
-            device.hideElement({
+            var animHandle = device.hideElement({
                 el: self.div,
                 skipAnim: false
             });
-
+            assertInstanceOf(AnimationHandle, animHandle);
             assertEquals('hidden', self.div.style.visibility);
             assertEquals(0, parseFloat(self.div.style.opacity));
         }, config);
@@ -484,64 +485,64 @@
     // TODO: need to test that hideElement() with skipAnim = false calls onComplete eventually
 
     this.CSS3AnimationTest.prototype.testHideElementWithNoAnimCallsOnCompleteImmediately = function(queue) {
-        expectAsserts(1);
-
-        var self = this;
-        var config = getDefaultCssConfig();
-
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, onCompleteStub;
-            device = application.getDevice();
-            onCompleteStub = self.sandbox.stub();
-            createScrollableDiv(self,device);
-
-            device.hideElement({
-                el: self.div,
-                skipAnim: true,
-                onComplete: onCompleteStub
-            });
-
-            assert(onCompleteStub.calledOnce);
-        }, config);
-    };
-
-    this.CSS3AnimationTest.prototype.testHideElementWithNoAnimInConfigCallsOnCompleteImmediately = function(queue) {
-        expectAsserts(1);
-
-        var self = this;
-        var config = getDefaultCssConfig();
-        config.animationDisabled = 'true';
-
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, onCompleteStub;
-            device = application.getDevice();
-            onCompleteStub = self.sandbox.stub();
-            createScrollableDiv(self,device);
-
-            device.hideElement({
-                el: self.div,
-                onComplete: onCompleteStub
-            });
-
-            assert(onCompleteStub.calledOnce);
-        }, config);
-    };
-
-    this.CSS3AnimationTest.prototype.testShowElement = function(queue) {
         expectAsserts(2);
 
         var self = this;
         var config = getDefaultCssConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, onCompleteStub, animHandle;
+            device = application.getDevice();
+            onCompleteStub = self.sandbox.stub();
+            createScrollableDiv(self,device);
+
+            animHandle = device.hideElement({
+                el: self.div,
+                skipAnim: true,
+                onComplete: onCompleteStub
+            });
+            assertInstanceOf(AnimationHandle, animHandle);
+            assert(onCompleteStub.calledOnce);
+        }, config);
+    };
+
+    this.CSS3AnimationTest.prototype.testHideElementWithNoAnimInConfigCallsOnCompleteImmediately = function(queue) {
+        expectAsserts(2);
+
+        var self = this;
+        var config = getDefaultCssConfig();
+        config.animationDisabled = 'true';
+
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, onCompleteStub, animHandle;
+            device = application.getDevice();
+            onCompleteStub = self.sandbox.stub();
+            createScrollableDiv(self,device);
+
+            animHandle = device.hideElement({
+                el: self.div,
+                onComplete: onCompleteStub
+            });
+            assertInstanceOf(AnimationHandle, animHandle);
+            assert(onCompleteStub.calledOnce);
+        }, config);
+    };
+
+    this.CSS3AnimationTest.prototype.testShowElement = function(queue) {
+        expectAsserts(3);
+
+        var self = this;
+        var config = getDefaultCssConfig();
+
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
             var device = application.getDevice();
             createScrollableDiv(self,device);
 
-            device.showElement({
+            var animHandle = device.showElement({
                 el: self.div,
                 skipAnim: false
             });
-
+            assertInstanceOf(AnimationHandle, animHandle);
             assertEquals('visible', self.div.style.visibility);
             assertEquals(1, parseFloat(self.div.style.opacity));
         }, config);
@@ -550,45 +551,45 @@
     // TODO: need to test that showElement() with skipAnim = false calls onComplete eventually
 
     this.CSS3AnimationTest.prototype.testShowElementWithNoAnimCallsOnCompleteImmediately = function(queue) {
-        expectAsserts(1);
+        expectAsserts(2);
 
         var self = this;
         var config = getDefaultCssConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, onCompleteStub;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, onCompleteStub, animHandle;
             device = application.getDevice();
             onCompleteStub = self.sandbox.stub();
             createScrollableDiv(self,device);
 
-            device.showElement({
+            animHandle = device.showElement({
                 el: self.div,
                 skipAnim: true,
                 onComplete: onCompleteStub
             });
-
+            assertInstanceOf(AnimationHandle, animHandle);
             assert(onCompleteStub.calledOnce);
         }, config);
     };
 
     this.CSS3AnimationTest.prototype.testShowElementWithNoAnimInConfigCallsOnCompleteImmediately = function(queue) {
-        expectAsserts(1);
+        expectAsserts(2);
 
         var self = this;
         var config = getDefaultCssConfig();
         config.animationDisabled = 'true';
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, onCompleteStub;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, onCompleteStub, animHandle;
             device = application.getDevice();
             onCompleteStub = self.sandbox.stub();
             createScrollableDiv(self,device);
 
-            device.showElement({
+            animHandle = device.showElement({
                 el: self.div,
                 onComplete: onCompleteStub
             });
-
+            assertInstanceOf(AnimationHandle, animHandle);
             assert(onCompleteStub.calledOnce);
         }, config);
     };
@@ -802,7 +803,7 @@
     };
 
     this.CSS3AnimationTest.prototype.testTweenElementStyleSetsStartAndEnd = function(queue) {
-        expectAsserts(2);
+        expectAsserts(3);
 
         var self = this;
         var config = getDefaultCssConfig();
@@ -810,9 +811,9 @@
         queuedApplicationInit(
             queue,
             'lib/mockapplication',
-            ['antie/devices/anim/css3/transitionelement'],
-            function(application, TransitionElement) {
-                var device, el, options, setSpy;
+            ['antie/devices/anim/css3/transitionelement', 'antie/devices/anim/shared/animationhandle'],
+            function(application, TransitionElement, AnimationHandle) {
+                var device, el, options, setSpy, animHandle;
                 device = application.getDevice();
                 el = getElement({
                     width: '10px',
@@ -829,7 +830,8 @@
 
                 self.sandbox.stub(TransitionElement.prototype, 'getComputedStyle');
 
-                device.tweenElementStyle(options);
+                animHandle = device.tweenElementStyle(options);
+                assertInstanceOf(AnimationHandle, animHandle);
                 assertTrue('From value set on element', setSpy.calledWith('width', '60px'));
                 assertTrue('To value set on element', setSpy.calledWith('width', '100px'));
             },

--- a/static/script-tests/tests/devices/anim/noanim.js
+++ b/static/script-tests/tests/devices/anim/noanim.js
@@ -59,18 +59,18 @@
     };
 
     this.NoAnimAnimationTest.prototype.testScrollElementTo = function(queue) {
-        expectAsserts(3);
+        expectAsserts(4);
 
         var config = getConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
             var device = application.getDevice();
             var div = device.createContainer('id_mask');
             var inner = device.createContainer('id');
             device.appendChildElement(div, inner);
 
             var onComplete = this.sandbox.stub();
-            device.scrollElementTo({
+            var animHandle = device.scrollElementTo({
                 el: div,
                 style: div.style,
                 to: {
@@ -79,7 +79,7 @@
                 },
                 onComplete: onComplete
             });
-
+            assertInstanceOf(AnimationHandle, animHandle);
             assertEquals(-100, parseFloat(inner.style.left.replace(/px$/, '')));
             assertEquals(-200, parseFloat(inner.style.top.replace(/px$/, '')));
             assert(onComplete.calledOnce);
@@ -87,16 +87,16 @@
     };
 
     this.NoAnimAnimationTest.prototype.testMoveElementTo = function(queue) {
-        expectAsserts(3);
+        expectAsserts(4);
 
         var config = getConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
             var device = application.getDevice();
             var div = device.createContainer('id');
 
             var onComplete = this.sandbox.stub();
-            device.moveElementTo({
+            var animHandle = device.moveElementTo({
                 el: div,
                 style: div.style,
                 to: {
@@ -106,7 +106,7 @@
                 skipAnim: true,
                 onComplete: onComplete
             });
-
+            assertInstanceOf(AnimationHandle, animHandle);
             assertEquals(100, parseFloat(div.style.left.replace(/px$/, '')));
             assertEquals(200, parseFloat(div.style.top.replace(/px$/, '')));
             assert(onComplete.calledOnce);
@@ -115,21 +115,21 @@
     };
 
     this.NoAnimAnimationTest.prototype.testHideElement = function(queue) {
-        expectAsserts(3);
+        expectAsserts(4);
 
         var config = getConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
             var device = application.getDevice();
             var div = device.createContainer();
 
             var onComplete = this.sandbox.stub();
 
-            device.hideElement({
+            var animHandle = device.hideElement({
                 el: div,
                 onComplete: onComplete
             });
-
+            assertInstanceOf(AnimationHandle, animHandle);
             assertEquals(0, parseFloat(div.style.opacity));
             assertEquals('hidden', div.style.visibility);
             assert(onComplete.calledOnce);
@@ -138,21 +138,21 @@
     };
 
     this.NoAnimAnimationTest.prototype.testShowElement = function(queue) {
-        expectAsserts(3);
+        expectAsserts(4);
 
         var config = getConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
             var device = application.getDevice();
             var div = device.createContainer();
 
             var onComplete = this.sandbox.stub();
 
-            device.showElement({
+            var animHandle = device.showElement({
                 el: div,
                 onComplete: onComplete
             });
-
+            assertInstanceOf(AnimationHandle, animHandle);
             assertEquals(1, parseFloat(div.style.opacity));
             assertEquals('visible', div.style.visibility);
             assert(onComplete.calledOnce);
@@ -210,11 +210,11 @@
     };
 
     this.NoAnimAnimationTest.prototype.testTweenElementFiresCallback = function(queue) {
-        expectAsserts(1);
+        expectAsserts(2);
         var config;
         config = getConfig();
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application){
-            var device, div, options, spy;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle){
+            var device, div, options, spy, animHandle;
             device = application.getDevice();
             div = device.createContainer();
             options = {
@@ -225,7 +225,8 @@
             };
 
             spy = this.sandbox.spy(options, 'onComplete');
-            device.tweenElementStyle(options);
+            animHandle = device.tweenElementStyle(options);
+            assertInstanceOf(AnimationHandle, animHandle);
             assertTrue('onComplete fired', spy.calledOnce);
         }, config);
     };

--- a/static/script-tests/tests/devices/anim/styletopleft.js
+++ b/static/script-tests/tests/devices/anim/styletopleft.js
@@ -66,13 +66,13 @@
     };
 
     this.StyleTopLeftAnimationTest.prototype.testScrollElementToWithAnim = function(queue) {
-        expectAsserts(3);
+        expectAsserts(4);
 
         var self = this;
         var config = getDefaultConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, div, inner;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, div, inner, animHandle;
             device = application.getDevice();
             div = device.createContainer('id_mask');
             inner = device.createContainer('id');
@@ -81,7 +81,7 @@
             var clock = sinon.useFakeTimers();
             var onComplete = self.sandbox.stub();
 
-            device.scrollElementTo({
+            animHandle = device.scrollElementTo({
                 el: div,
                 style: div.style,
                 to: {
@@ -97,19 +97,19 @@
             assertEquals(-100, parseFloat(inner.style.left.replace(/px$/, '')));
             assertEquals(-200, parseFloat(inner.style.top.replace(/px$/, '')));
             assert(onComplete.calledOnce);
-
+            assertInstanceOf(AnimationHandle, animHandle);
             clock.restore();
 
         }, config);
     };
     this.StyleTopLeftAnimationTest.prototype.testScrollElementToWithAnimNoMovement = function(queue) {
-        expectAsserts(1);
+        expectAsserts(2);
 
         var config = getDefaultConfig();
         var self = this;
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, div, inner;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, div, inner, animHandle;
             device = application.getDevice();
             div = device.createContainer('id_mask');
             inner = device.createContainer('id');
@@ -120,7 +120,7 @@
 
             var onComplete = self.sandbox.stub();
 
-            device.scrollElementTo({
+            animHandle = device.scrollElementTo({
                 el: div,
                 style: div.style,
                 to: {
@@ -129,19 +129,19 @@
                 },
                 onComplete: onComplete
             });
-
+            assertInstanceOf(AnimationHandle, animHandle);
             assert(onComplete.calledOnce);
 
         }, config);
     };
     this.StyleTopLeftAnimationTest.prototype.testScrollElementToWithNoAnim = function(queue) {
-        expectAsserts(3);
+        expectAsserts(4);
 
         var config = getDefaultConfig();
         var self = this;
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, div, inner;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, div, inner, animHandle;
             device = application.getDevice();
             div = device.createContainer('id_mask');
             inner = device.createContainer('id');
@@ -149,7 +149,7 @@
 
             var onComplete = self.sandbox.stub();
 
-            device.scrollElementTo({
+            animHandle = device.scrollElementTo({
                 el: div,
                 style: div.style,
                 to: {
@@ -163,7 +163,7 @@
             assertEquals(-100, parseFloat(inner.style.left.replace(/px$/, '')));
             assertEquals(-200, parseFloat(inner.style.top.replace(/px$/, '')));
             assert(onComplete.calledOnce);
-
+            assertInstanceOf(AnimationHandle, animHandle);
         }, config);
     };
 
@@ -171,13 +171,13 @@
      * Test scrollElementTo() skips animation when specified in config.
      */
     this.StyleTopLeftAnimationTest.prototype.testScrollElementToWithNoAnimInConfig = function(queue) {
-        expectAsserts(3);
+        expectAsserts(4);
 
         var self = this;
         var config = getDefaultConfig();
         config.animationDisabled = 'true';
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, div, inner;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, div, inner, animHandle;
             device = application.getDevice();
             div = device.createContainer('id_mask');
             inner = device.createContainer('id');
@@ -185,7 +185,7 @@
 
             var onComplete = self.sandbox.stub();
 
-            device.scrollElementTo({
+            animHandle = device.scrollElementTo({
                 el: div,
                 style: div.style,
                 to: {
@@ -197,26 +197,27 @@
             assertEquals(-100, parseFloat(inner.style.left.replace(/px$/, '')));
             assertEquals(-200, parseFloat(inner.style.top.replace(/px$/, '')));
             assert(onComplete.calledOnce);
+            assertInstanceOf(AnimationHandle, animHandle);
 
         }, config);
     };
 
 
     this.StyleTopLeftAnimationTest.prototype.testMoveElementToWithAnim = function(queue) {
-        expectAsserts(3);
+        expectAsserts(4);
 
         var self = this;
         var config = getDefaultConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, div;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, div, animHandle;
             device = application.getDevice();
             div = device.createContainer('id');
 
             var clock = sinon.useFakeTimers();
 
             var onComplete = self.sandbox.stub();
-            device.moveElementTo({
+            animHandle = device.moveElementTo({
                 el: div,
                 style: div.style,
                 from: {
@@ -236,26 +237,26 @@
             assertEquals(100, parseFloat(div.style.left.replace(/px$/, '')));
             assertEquals(200, parseFloat(div.style.top.replace(/px$/, '')));
             assert(onComplete.calledOnce);
-
+            assertInstanceOf(AnimationHandle, animHandle);
             clock.restore();
         }, config);
     };
 
     this.StyleTopLeftAnimationTest.prototype.testMoveElementToWithAnimAndNoDefaultValues = function(queue) {
-        expectAsserts(3);
+        expectAsserts(4);
 
         var self = this;
         var config = getDefaultConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, div;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, div, animHandle;
             device = application.getDevice();
             div = device.createContainer('id');
 
             var clock = sinon.useFakeTimers();
             var onComplete = self.sandbox.stub();
 
-            device.moveElementTo({
+            animHandle = device.moveElementTo({
                 el: div,
                 style: div.style,
                 from: {
@@ -275,27 +276,27 @@
             assertEquals(100, parseFloat(div.style.left.replace(/px$/, '')));
             assertEquals(200, parseFloat(div.style.top.replace(/px$/, '')));
             assert(onComplete.calledOnce);
-
+            assertInstanceOf(AnimationHandle, animHandle);
             clock.restore();
 
         }, config);
     };
 
     this.StyleTopLeftAnimationTest.prototype.testHideElementWithAnimAndNoDefaultOpacity = function(queue) {
-        expectAsserts(2);
+        expectAsserts(3);
 
         var self = this;
         var config = getDefaultConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, div;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, div, animHandle;
             device = application.getDevice();
             div = device.createContainer('id');
 
             var clock = sinon.useFakeTimers();
             var onComplete = self.sandbox.stub();
 
-            device.hideElement({
+            animHandle = device.hideElement({
                 el: div,
                 style: div.style,
                 from: {
@@ -312,7 +313,7 @@
 
             assertEquals(0, parseFloat(div.style.opacity));
             assert(onComplete.calledOnce);
-
+            assertInstanceOf(AnimationHandle, animHandle);
             clock.restore();
 
         }, config);
@@ -383,20 +384,20 @@
 
 
     this.StyleTopLeftAnimationTest.prototype.testMoveElementToWithNoLeftValue = function(queue) {
-        expectAsserts(3);
+        expectAsserts(4);
 
         var self = this;
         var config = getDefaultConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, div;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, div, animHandle;
             device = application.getDevice();
             div = device.createContainer('id');
 
             var clock = sinon.useFakeTimers();
             var onComplete = self.sandbox.stub();
 
-            device.moveElementTo({
+            animHandle = device.moveElementTo({
                 el: div,
                 style: div.style,
                 from: {
@@ -414,27 +415,27 @@
             assert(onComplete.calledOnce);
             assertEquals(0, parseFloat(div.style.left.replace(/px$/, '')));
             assertEquals(200, parseFloat(div.style.top.replace(/px$/, '')));
-
+            assertInstanceOf(AnimationHandle, animHandle);
             clock.restore();
 
         }, config);
     };
 
     this.StyleTopLeftAnimationTest.prototype.testMoveElementToWithNoTopValue = function(queue) {
-        expectAsserts(3);
+        expectAsserts(4);
 
         var self = this;
         var config = getDefaultConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, div;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, div, animHandle;
             device = application.getDevice();
             div = device.createContainer('id');
 
             var clock = sinon.useFakeTimers();
             var onComplete = self.sandbox.stub();
 
-            device.moveElementTo({
+            animHandle = device.moveElementTo({
                 el: div,
                 style: div.style,
                 from: {
@@ -452,20 +453,20 @@
             assert(onComplete.calledOnce);
             assertEquals(100, parseFloat(div.style.left.replace(/px$/, '')));
             assertEquals(0, parseFloat(div.style.top.replace(/px$/, '')));
-
+            assertInstanceOf(AnimationHandle, animHandle);
             clock.restore();
 
         }, config);
     };
 
     this.StyleTopLeftAnimationTest.prototype.testMoveElementToWithAnimNoMovement = function(queue) {
-        expectAsserts(1);
+        expectAsserts(2);
 
         var self = this;
         var config = getDefaultConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, div;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, div, animHandle;
             device = application.getDevice();
             div = device.createContainer('id');
 
@@ -474,7 +475,7 @@
 
             var onComplete = self.sandbox.stub();
 
-            device.moveElementTo({
+            animHandle = device.moveElementTo({
                 el: div,
                 style: div.style,
                 to: {
@@ -483,25 +484,25 @@
                 },
                 onComplete: onComplete
             });
-
+            assertInstanceOf(AnimationHandle, animHandle);
             assert(onComplete.calledOnce);
 
         }, config);
     };
     this.StyleTopLeftAnimationTest.prototype.testMoveElementToWithNoAnim = function(queue) {
-        expectAsserts(3);
+        expectAsserts(4);
 
         var self = this;
         var config = getDefaultConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, div;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, div, animHandle;
             device = application.getDevice();
             div = device.createContainer('id');
 
             var onComplete = self.sandbox.stub();
 
-            device.moveElementTo({
+            animHandle = device.moveElementTo({
                 el: div,
                 style: div.style,
                 to: {
@@ -515,7 +516,7 @@
             assert(onComplete.calledOnce);
             assertEquals(100, parseFloat(div.style.left.replace(/px$/, '')));
             assertEquals(200, parseFloat(div.style.top.replace(/px$/, '')));
-
+            assertInstanceOf(AnimationHandle, animHandle);
         }, config);
     };
 
@@ -523,19 +524,19 @@
      * Test moveElementTo() skips animation when specified in config.
      */
     this.StyleTopLeftAnimationTest.prototype.testMoveElementToWithNoAnimInConfig = function(queue) {
-        expectAsserts(3);
+        expectAsserts(4);
 
         var self = this;
         var config = getDefaultConfig();
         config.animationDisabled = 'true';
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, div;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, div, animHandle;
             device = application.getDevice();
             div = device.createContainer('id');
 
             var onComplete = self.sandbox.stub();
 
-            device.moveElementTo({
+            animHandle = device.moveElementTo({
                 el: div,
                 style: div.style,
                 to: {
@@ -548,25 +549,25 @@
             assert(onComplete.calledOnce);
             assertEquals(100, parseFloat(div.style.left.replace(/px$/, '')));
             assertEquals(200, parseFloat(div.style.top.replace(/px$/, '')));
-
+            assertInstanceOf(AnimationHandle, animHandle);
         }, config);
     };
 
     this.StyleTopLeftAnimationTest.prototype.testHideElementWithAnim = function(queue) {
-        expectAsserts(3);
+        expectAsserts(4);
 
         var self = this;
         var config = getDefaultConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, div;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, div, animHandle;
             device = application.getDevice();
             div = device.createContainer('id');
 
             var clock = sinon.useFakeTimers();
             var onComplete = self.sandbox.stub();
 
-            device.hideElement({
+            animHandle = device.hideElement({
                 el: div,
                 skipAnim: false,
                 onComplete: onComplete
@@ -577,25 +578,25 @@
             assert(onComplete.calledOnce);
             assertEquals('hidden', div.style.visibility);
             assertEquals(0, parseFloat(div.style.opacity));
-
+            assertInstanceOf(AnimationHandle, animHandle);
             clock.restore();
 
         }, config);
     };
     this.StyleTopLeftAnimationTest.prototype.testHideElementWithNoAnim = function(queue) {
-        expectAsserts(3);
+        expectAsserts(4);
 
         var config = getDefaultConfig();
         var self = this;
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, div;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, div, animHandle;
             device = application.getDevice();
             div = device.createContainer('id');
 
             var onComplete = self.sandbox.stub();
 
-            device.hideElement({
+            animHandle = device.hideElement({
                 el: div,
                 skipAnim: true,
                 onComplete: onComplete
@@ -604,7 +605,7 @@
             assert(onComplete.calledOnce);
             assertEquals('hidden', div.style.visibility);
             assertEquals(0, parseFloat(div.style.opacity));
-
+            assertInstanceOf(AnimationHandle, animHandle);
         }, config);
     };
 
@@ -612,19 +613,19 @@
      * Test hideElement() skips animation when specified in config.
      */
     this.StyleTopLeftAnimationTest.prototype.testHideElementWithNoAnimInConfig = function(queue) {
-        expectAsserts(3);
+        expectAsserts(4);
 
         var self = this;
         var config = getDefaultConfig();
         config.animationDisabled = 'true';
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, div;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, div, animHandle;
             device = application.getDevice();
             div = device.createContainer('id');
 
             var onComplete = self.sandbox.stub();
 
-            device.hideElement({
+            animHandle = device.hideElement({
                 el: div,
                 onComplete: onComplete
             });
@@ -632,25 +633,25 @@
             assert(onComplete.calledOnce);
             assertEquals('hidden', div.style.visibility);
             assertEquals(0, parseFloat(div.style.opacity));
-
+            assertInstanceOf(AnimationHandle, animHandle);
         }, config);
     };
 
     this.StyleTopLeftAnimationTest.prototype.testShowElementWithAnim = function(queue) {
-        expectAsserts(3);
+        expectAsserts(4);
 
         var self = this;
         var config = getDefaultConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, div;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, div, animHandle;
             device = application.getDevice();
             div = device.createContainer('id');
 
             var clock = sinon.useFakeTimers();
             var onComplete = self.sandbox.stub();
 
-            device.showElement({
+            animHandle = device.showElement({
                 el: div,
                 skipAnim: false,
                 onComplete: onComplete
@@ -661,26 +662,26 @@
             assert(onComplete.calledOnce);
             assertEquals('visible', div.style.visibility);
             assertEquals(1, parseFloat(div.style.opacity));
-
+            assertInstanceOf(AnimationHandle, animHandle);
             clock.restore();
 
         }, config);
     };
 
     this.StyleTopLeftAnimationTest.prototype.testShowElementWithNoAnim = function(queue) {
-        expectAsserts(3);
+        expectAsserts(4);
 
         var self = this;
         var config = getDefaultConfig();
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, div;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, div, animHandle;
             device = application.getDevice();
             div = device.createContainer('id');
 
             var onComplete = self.sandbox.stub();
 
-            device.showElement({
+            animHandle = device.showElement({
                 el: div,
                 skipAnim: true,
                 onComplete: onComplete
@@ -689,6 +690,7 @@
             assert(onComplete.calledOnce);
             assertEquals('visible', div.style.visibility);
             assertEquals(1, parseFloat(div.style.opacity));
+            assertInstanceOf(AnimationHandle, animHandle);
 
         }, config);
     };
@@ -697,20 +699,20 @@
      * Test showElement() skips animation when specified in config.
      */
     this.StyleTopLeftAnimationTest.prototype.testShowElementWithNoAnimInConfig = function(queue) {
-        expectAsserts(3);
+        expectAsserts(4);
 
         var self = this;
         var config = getDefaultConfig();
         config.animationDisabled = 'true';
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
-            var device, div;
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
+            var device, div, animHandle;
             device = application.getDevice();
             div = device.createContainer('id');
 
             var onComplete = self.sandbox.stub();
 
-            device.showElement({
+            animHandle = device.showElement({
                 el: div,
                 onComplete: onComplete
             });
@@ -718,6 +720,7 @@
             assert(onComplete.calledOnce);
             assertEquals('visible', div.style.visibility);
             assertEquals(1, parseFloat(div.style.opacity));
+            assertInstanceOf(AnimationHandle, animHandle);
 
         }, config);
     };
@@ -971,13 +974,13 @@
     this.StyleTopLeftAnimationTest.prototype.testTweenElementStyleFiresOnCompleteWhenSkipped = function(queue) {
         var config = getDefaultConfig();
         var self = this;
-        expectAsserts(1);
+        expectAsserts(2);
         queuedApplicationInit(
             queue,
             'lib/mockapplication',
-            [],
-            function(application) {
-                var device, el, options, completeSpy;
+            ['antie/devices/anim/shared/animationhandle'],
+            function(application, AnimationHandle) {
+                var device, el, options, completeSpy, animHandle;
                 el = {
                     style: {
                         getPropertyValue: function(property) {
@@ -1007,8 +1010,9 @@
 
                 device = application.getDevice();
                 completeSpy = self.sandbox.spy(options, 'onComplete');
-                device.tweenElementStyle(options);
+                animHandle = device.tweenElementStyle(options);
                 assertTrue('onComplete called', completeSpy.calledOnce);
+                assertInstanceOf(AnimationHandle, animHandle);
             },
             config
         );
@@ -1017,13 +1021,13 @@
     this.StyleTopLeftAnimationTest.prototype.testTweenElementStyleFiresOnCompleteWhenNoChange = function(queue) {
         var config = getDefaultConfig();
         var self = this;
-        expectAsserts(1);
+        expectAsserts(2);
         queuedApplicationInit(
             queue,
             'lib/mockapplication',
-            [],
-            function(application) {
-                var device, el, options, completeSpy;
+            ['antie/devices/anim/shared/animationhandle'],
+            function(application, AnimationHandle) {
+                var device, el, options, completeSpy, animHandle;
                 el = {
                     style: {
                         getPropertyValue: function(property) {
@@ -1047,8 +1051,9 @@
 
                 device = application.getDevice();
                 completeSpy = self.sandbox.spy(options, 'onComplete');
-                device.tweenElementStyle(options);
+                animHandle = device.tweenElementStyle(options);
                 assertTrue('onComplete called', completeSpy.calledOnce);
+                assertInstanceOf(AnimationHandle, animHandle);
             },
             config
         );
@@ -1150,16 +1155,17 @@
         );
     };
 
-    this.StyleTopLeftAnimationTest.prototype.testTweenElementStyleEqualEndpointsReturnNull = function(queue) {
-        var config;
+    this.StyleTopLeftAnimationTest.prototype.testTweenElementStyleEqualEndpointsCompletesImmediately = function(queue) {
+        var config, self;
         config = getDefaultConfig();
+        self = this;
 
         queuedApplicationInit(
             queue,
             'lib/mockapplication',
-            [],
-            function(application) {
-                var el, device, tween;
+            ['antie/devices/anim/shared/animationhandle'],
+            function(application, AnimationHandle) {
+                var el, device, options, animHandle, onComplete;
                 device = application.getDevice();
                 el = {
                     style: {
@@ -1170,18 +1176,19 @@
                         right: '600px'
                     }
                 };
-                tween = device.tweenElementStyle(
-                    {
-                        el: el,
-                        to: {
-                            bottom: 0,
-                            right: 600
-                        },
-                        duration: 30
-                    }
-                );
-
-                assertEquals('Equal Endpoints return null', tween, null);
+                onComplete = self.sandbox.stub();
+                options =  {
+                    el: el,
+                    to: {
+                        bottom: 0,
+                        right: 600
+                    },
+                    duration: 30,
+                    onComplete : onComplete
+                };
+                animHandle = device.tweenElementStyle( options );
+                assert(onComplete.calledOnce);
+                assertInstanceOf(AnimationHandle, animHandle);
             },
             config
         );
@@ -1194,9 +1201,9 @@
         queuedApplicationInit(
             queue,
             'lib/mockapplication',
-            [],
-            function(application) {
-                var el, device;
+            ['antie/devices/anim/shared/animationhandle'],
+            function(application, AnimationHandle) {
+                var el, device, animHandle;
                 device = application.getDevice();
                 el = {
                     style: {
@@ -1207,7 +1214,7 @@
                         right: '600px'
                     }
                 };
-                device.tweenElementStyle(
+                animHandle = device.tweenElementStyle(
                     {
                         el: el,
                         to: {
@@ -1218,7 +1225,7 @@
                         skipAnim: true
                     }
                 );
-
+                assertInstanceOf(AnimationHandle, animHandle);
                 assertEquals('Bottom target reached immediately', '100px', el.style.bottom);
             },
             config
@@ -1233,9 +1240,9 @@
         queuedApplicationInit(
             queue,
             'lib/mockapplication',
-            [],
-            function(application) {
-                var el, device;
+            ['antie/devices/anim/shared/animationhandle'],
+            function(application, AnimationHandle) {
+                var el, device, animHandle;
                 device = application.getDevice();
                 el = {
                     style: {
@@ -1246,7 +1253,7 @@
                         right: '600px'
                     }
                 };
-                device.tweenElementStyle(
+                animHandle = device.tweenElementStyle(
                     {
                         el: el,
                         to: {
@@ -1256,7 +1263,7 @@
                         duration: 3000
                     }
                 );
-
+                assertInstanceOf(AnimationHandle, animHandle);
                 assertEquals('Bottom target reached immediately', '100px', el.style.bottom);
             },
             config
@@ -1410,7 +1417,8 @@
 
             clock.tick(100);
 
-            device.stopAnimation(anim);
+            //device.stopAnimation(anim);
+            anim.stop(true);
             assertEquals('Element in its end position (left)', '100px', div.style.left);
             assertEquals('Element in its end position (top)', '200px', div.style.top);
 

--- a/static/script-tests/tests/devices/anim/tween.js
+++ b/static/script-tests/tests/devices/anim/tween.js
@@ -44,17 +44,17 @@
     };
 
     this.TweenAnimationTest.prototype.testTween = function(queue) {
-        expectAsserts(2);
+        expectAsserts(3);
 
         var config = {'modules':{'base':'antie/devices/browserdevice','modifiers':['antie/devices/anim/styletopleft']},'input':{'map':{}},'layouts':[{'width':960,'height':540,'module':'fixtures/layouts/default','classes':['browserdevice540p']}],'deviceConfigurationKey':'devices-html5-1'};
 
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function(application) {
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/anim/shared/animationhandle'], function(application, AnimationHandle) {
             var device = application.getDevice();
             var div = device.createContainer();
 
             var clock = sinon.useFakeTimers();
 
-            device._tween({
+            var animHandle = device._tween({
                 el: div,
                 style: div.style,
                 from: {
@@ -66,6 +66,8 @@
                 className: null
             });
 
+            assertInstanceOf(AnimationHandle, animHandle);
+            
             assertEquals(0, Math.round(parseFloat(div.style.top.replace(/px$/,''))));
 
             clock.tick(DEFAULT_TWEEN_TIME);

--- a/static/script/devices/anim/css3.js
+++ b/static/script/devices/anim/css3.js
@@ -30,9 +30,10 @@ define(
         'antie/devices/browserdevice',
         'antie/devices/anim/css3/transition',
         'antie/devices/anim/css3/optionstransitiondefinition',
-        'antie/devices/anim/shared/transitionendpoints'
+        'antie/devices/anim/shared/transitionendpoints',
+        'antie/devices/anim/shared/animationhandle'
     ],
-    function(Device,  Transition, OptionsTransitionDefinition, TransitionEndPoints) {
+    function(Device,  Transition, OptionsTransitionDefinition, TransitionEndPoints, AnimationHandle) {
         'use strict';
 
         function shouldSkipAnim(options, device) {
@@ -44,6 +45,12 @@ define(
                 return device.getConfig().defaults[propertyName];
             }
             return undefined;
+        }
+
+        function animationHandle(trans){
+            return new AnimationHandle( function(gotoEnd){
+                trans.stop(gotoEnd);
+            });
         }
 
         /* documented in antie.devices.Device */
@@ -82,7 +89,7 @@ define(
                 options.el
             );
 
-            return (trans._completed ? null : trans);
+            return animationHandle(trans);
         };
 
         /* documented in antie.devices.Device */
@@ -107,12 +114,12 @@ define(
                 );
             }
 
-            return (trans._completed ? null : trans);
+            return animationHandle(trans);
         };
 
         /* documented in antie.devices.device */
         Device.prototype.showElement = function(options) {
-            var transDef, transEndPoints, transOpts, config;
+            var transDef, transEndPoints, transOpts, config, trans;
             config = getConfig('showElementFade', this);
             transOpts = {
                 to: {
@@ -132,16 +139,17 @@ define(
             transDef.setPropertyDuration('visibility', 0);
             transEndPoints = new TransitionEndPoints(transOpts);
 
-            return new Transition(
+            trans = new Transition(
                 transDef,
                 transEndPoints,
                 options.el
             );
+            return animationHandle(trans);
         };
 
         /* documented in antie.devices.device - easing and fps not yet implemented here */
         Device.prototype.hideElement = function(options) {
-            var transDef, transEndPoints, transOpts, config;
+            var transDef, transEndPoints, transOpts, config, trans;
             config = getConfig('hideElementFade', this);
             transOpts = {
                 to: {
@@ -161,12 +169,13 @@ define(
             transDef.setPropertyDelay('visibility', transDef.getPropertyDuration('opacity'));
             transEndPoints = new TransitionEndPoints(transOpts);
 
-            return new Transition(
+            trans = new Transition(
                 transDef,
                 transEndPoints,
                 options.el
             );
 
+            return animationHandle(trans);
         };
 
         Device.prototype.tweenElementStyle = function(options) {
@@ -183,12 +192,11 @@ define(
                 }
             );
 
-            return new Transition(
+            return animationHandle(new Transition(
                 transDef,
                 transEndPoints,
                 options.el
-            );
-
+            ));
         };
 
         /* documented in antie.devices.device */
@@ -196,8 +204,11 @@ define(
             return false;
         };
 
-        Device.prototype.stopAnimation = function(transition) {
-            transition.stop(true);
+        /**
+          * @deprecated just call stop on the animation handle itself
+          */
+        Device.prototype.stopAnimation = function(animHandle) {
+            animHandle.stop(true);
         };
     }
 );

--- a/static/script/devices/anim/noanim.js
+++ b/static/script/devices/anim/noanim.js
@@ -28,22 +28,25 @@ define(
     'antie/devices/anim/noanim',
     [
         'antie/devices/browserdevice',
-        'antie/devices/anim/shared/transitionendpoints'
+        'antie/devices/anim/shared/transitionendpoints',
+        'antie/devices/anim/shared/animationhandle'
     ],
-    function(Device, TransitionEndPoints) {
+    function(Device, TransitionEndPoints, AnimationHandle) {
         'use strict';
 
+        var animHandle = new AnimationHandle();
+        
         /* documented in antie.devices.Device */
         Device.prototype.scrollElementTo = function(options) {
             if(new RegExp('_mask$').test(options.el.id)) {
                 if (options.el.childNodes.length === 0) {
-                    return null;
+                    return animHandle;
                 }
                 options.el.style.position = 'relative';
                 options.el = options.el.childNodes[0];
                 options.el.style.position = 'relative';
             } else {
-                return null;
+                return animHandle;
             }
             var startLeft = Math.abs(options.el.style.left.replace(/px/, '')) || 0;
             var changeLeft = (options.to.left !== undefined) ? (options.to.left - startLeft) : 0;
@@ -53,7 +56,7 @@ define(
                 if (options.onComplete) {
                     options.onComplete();
                 }
-                return null;
+                return animHandle;
             }
 
             if (options.to.left !== undefined) {
@@ -66,7 +69,7 @@ define(
                 options.onComplete();
             }
 
-            return null;
+            return animHandle;
         };
 
         /* documented in antie.devices.Device */
@@ -83,7 +86,7 @@ define(
                 if (options.onComplete) {
                     options.onComplete();
                 }
-                return null;
+                return animHandle;
             }
 
             if (options.to.left !== undefined) {
@@ -95,6 +98,8 @@ define(
             if (options.onComplete) {
                 options.onComplete();
             }
+
+            return animHandle;
         };
 
         /* documented in antie.devices.device */
@@ -104,6 +109,7 @@ define(
             if (typeof options.onComplete === 'function') {
                 options.onComplete();
             }
+            return animHandle;
         };
 
         /* documented in antie.devices.device */
@@ -113,6 +119,7 @@ define(
             if (typeof options.onComplete === 'function') {
                 options.onComplete();
             }
+            return animHandle;
         };
 
         Device.prototype.tweenElementStyle = function(options) {
@@ -136,6 +143,7 @@ define(
             if (typeof options.onComplete === 'function') {
                 options.onComplete();
             }
+            return animHandle;
         };
 
         /* documented in antie.devices.device */

--- a/static/script/devices/anim/noanim.js
+++ b/static/script/devices/anim/noanim.js
@@ -34,19 +34,19 @@ define(
     function(Device, TransitionEndPoints, AnimationHandle) {
         'use strict';
 
-        var animHandle = new AnimationHandle();
+        var nullObjectAnimHandle = new AnimationHandle();
         
         /* documented in antie.devices.Device */
         Device.prototype.scrollElementTo = function(options) {
             if(new RegExp('_mask$').test(options.el.id)) {
                 if (options.el.childNodes.length === 0) {
-                    return animHandle;
+                    return nullObjectAnimHandle;
                 }
                 options.el.style.position = 'relative';
                 options.el = options.el.childNodes[0];
                 options.el.style.position = 'relative';
             } else {
-                return animHandle;
+                return nullObjectAnimHandle;
             }
             var startLeft = Math.abs(options.el.style.left.replace(/px/, '')) || 0;
             var changeLeft = (options.to.left !== undefined) ? (options.to.left - startLeft) : 0;
@@ -56,7 +56,7 @@ define(
                 if (options.onComplete) {
                     options.onComplete();
                 }
-                return animHandle;
+                return nullObjectAnimHandle;
             }
 
             if (options.to.left !== undefined) {
@@ -69,7 +69,7 @@ define(
                 options.onComplete();
             }
 
-            return animHandle;
+            return nullObjectAnimHandle;
         };
 
         /* documented in antie.devices.Device */
@@ -86,7 +86,7 @@ define(
                 if (options.onComplete) {
                     options.onComplete();
                 }
-                return animHandle;
+                return nullObjectAnimHandle;
             }
 
             if (options.to.left !== undefined) {
@@ -99,7 +99,7 @@ define(
                 options.onComplete();
             }
 
-            return animHandle;
+            return nullObjectAnimHandle;
         };
 
         /* documented in antie.devices.device */
@@ -109,7 +109,7 @@ define(
             if (typeof options.onComplete === 'function') {
                 options.onComplete();
             }
-            return animHandle;
+            return nullObjectAnimHandle;
         };
 
         /* documented in antie.devices.device */
@@ -119,7 +119,7 @@ define(
             if (typeof options.onComplete === 'function') {
                 options.onComplete();
             }
-            return animHandle;
+            return nullObjectAnimHandle;
         };
 
         Device.prototype.tweenElementStyle = function(options) {
@@ -143,7 +143,7 @@ define(
             if (typeof options.onComplete === 'function') {
                 options.onComplete();
             }
-            return animHandle;
+            return nullObjectAnimHandle;
         };
 
         /* documented in antie.devices.device */

--- a/static/script/devices/anim/shared/animationhandle.js
+++ b/static/script/devices/anim/shared/animationhandle.js
@@ -1,0 +1,54 @@
+/**
+ * @fileOverview Requirejs module containing base antie.devices.anim.shared.animationhandle class.
+ *
+ * @preserve Copyright (c) 2013 British Broadcasting Corporation
+ * (http://www.bbc.co.uk) and TAL Contributors (1)
+ *
+ * (1) TAL Contributors are listed in the AUTHORS file and at
+ *     https://github.com/fmtvp/TAL/AUTHORS - please extend this file,
+ *     not this notice.
+ *
+ * @license Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * All rights reserved
+ * Please contact us for an alternative licence
+ */
+
+define(
+    'antie/devices/anim/shared/animationhandle',
+    [
+        'antie/class'
+    ],
+    function(Class) {
+        'use strict';
+        var AnimationHandle;
+
+        /*
+         * A wrapper class which exposes a stoppable animation
+         */
+        AnimationHandle = Class.extend(
+            {
+                init: function(target) {
+                    this._target = target;
+                },
+
+                stop : function(skipToEnd){
+                    if (typeof this._target === 'function') {
+                        this._target(skipToEnd);
+                    }
+                }
+            }
+        );
+        return AnimationHandle;
+    }
+);

--- a/static/script/devices/anim/styletopleft.js
+++ b/static/script/devices/anim/styletopleft.js
@@ -29,10 +29,13 @@ define(
     [
         'antie/devices/browserdevice',
         'antie/devices/anim/shared/transitionendpoints',
+        'antie/devices/anim/shared/animationhandle',
         'antie/devices/anim/tween'
     ],
-    function(Device, TransitionEndPoints)  {
+    function(Device, TransitionEndPoints, AnimationHandle)  {
         'use strict';
+
+        var skippedAnimationHandle = new AnimationHandle();
 
         function movesScroll( startLeft, startTop, changeLeft, changeTop, options ){
             var to, from;
@@ -40,7 +43,7 @@ define(
                 if (options.onComplete) {
                     options.onComplete();
                 }
-                return null;
+                return skippedAnimationHandle;
             }
 
             if (this.getConfig().animationDisabled || options.skipAnim) {
@@ -54,7 +57,7 @@ define(
                 if (options.onComplete) {
                     options.onComplete();
                 }
-                return null;
+                return skippedAnimationHandle;
             } else {
                 from = {};
                 if (startTop !== undefined) {
@@ -107,13 +110,13 @@ define(
             // Check validity of call and use child element as the real target
             if (new RegExp('_mask$').test(options.el.id)) {
                 if (options.el.childNodes.length === 0) {
-                    return null;
+                    return skippedAnimationHandle;
                 }
                 options.el.style.position = 'relative';
                 newOptions.el = options.el.childNodes[0];
                 newOptions.el.style.position = 'relative';
             } else {
-                return null;
+                return skippedAnimationHandle;
             }
 
             // Make a copy of the 'to' property, with the sign of the 'top' and 'left' properties flipped.
@@ -155,7 +158,7 @@ define(
                 if (typeof options.onComplete === 'function') {
                     options.onComplete();
                 }
-                return null;
+                return skippedAnimationHandle;
             } else {
                 animationDefaults = this.getConfig().defaults && this.getConfig().defaults.hideElementFade || {};
                 return this._tween({
@@ -189,7 +192,7 @@ define(
                 if (typeof options.onComplete === 'function') {
                     options.onComplete();
                 }
-                return undefined;
+                return skippedAnimationHandle;
             } else {
                 animationDefaults = this.getConfig().defaults && this.getConfig().defaults.showElementFade || {};
                 return this._tween({
@@ -258,13 +261,13 @@ define(
 
             if(endPoints.toAndFromAllEqual()) {
                 fireComplete();
-                return null;
+                return skippedAnimationHandle;
             }
 
             if(options.skipAnim  || this.getConfig().animationDisabled) {
                 skipAnimation();
                 fireComplete();
-                return undefined;
+                return skippedAnimationHandle;
             }
 
             return this._tween(getTweenOptions());

--- a/static/script/devices/anim/tween.js
+++ b/static/script/devices/anim/tween.js
@@ -28,9 +28,10 @@ define(
     'antie/devices/anim/tween',
     [
         'antie/devices/browserdevice',
-        'antie/lib/shifty'
+        'antie/lib/shifty',
+        'antie/devices/anim/shared/animationhandle'
     ],
-    function(Device, Tweenable) {
+    function(Device, Tweenable, AnimationHandle) {
         'use strict';
 
         // A set of queues of DOM updates to perform. Each animation framerate gets its own queue
@@ -191,7 +192,9 @@ define(
 
             anim.tween(opts);
 
-            return anim;
+            return new AnimationHandle(function(gotoEnd){
+                anim.stop(gotoEnd);
+            });
         };
     }
 );


### PR DESCRIPTION
FOR REVIEW/DISCUSSION NOT MERGE:
Expose an animation handle object as the return object for all animation calls. The handle explicitly exposes an interface for a caller to be able to request the animation is stopped. 

The Null Object pattern has been used - in the case that there is no animation to cancel an animation handle is still returned. This allows callers to not care about any of the internal implementation details of TAL animation. 
