### PR TITLE
Added transition object to aftershow event

### DIFF
--- a/static/script/events/componentevent.js
+++ b/static/script/events/componentevent.js
@@ -27,12 +27,13 @@ define(
              * @constructor
              * @ignore
              */
-            init: function(type, container, component, args, state, fromBack) {
+            init: function(type, container, component, args, state, fromBack, transition) {
                 this.container = container;
                 this.component = component;
                 this.args = args;
                 this.state = state;
                 this.fromBack = fromBack;
+                this.transition = transition;
                 this._super(type);
             }
         });

--- a/static/script/widgets/componentcontainer.js
+++ b/static/script/widgets/componentcontainer.js
@@ -129,16 +129,17 @@ define('antie/widgets/componentcontainer',
                     }
 
                     self = this;
+                    var transition;
                     if (!evt.isDefaultPrevented()) {
                         var config = device.getConfig();
                         var animate = !config.widgets || !config.widgets.componentcontainer || (config.widgets.componentcontainer.fade !== false);
-                        device.showElement({
+                        transition = device.showElement({
                             el: this._currentComponent.outputElement,
                             skipAnim: !animate
                         });
                     }
 
-                    self._currentComponent.bubbleEvent(new ComponentEvent('aftershow', self, self._currentComponent, args, state, fromBack));
+                    self._currentComponent.bubbleEvent(new ComponentEvent('aftershow', self, self._currentComponent, args, state, fromBack, transition));
 
                     var focusRemoved = self.setActiveChildWidget(self._currentComponent);
                     if (!focusRemoved) {


### PR DESCRIPTION
You often need the transition object when you are navigation quickly. To stop the previous animation on `componentcontainer.show()`.
