### PR TITLE
Issue #425 Allowing delete key on remote control to focus the DEL key…

### DIFF
--- a/static/script-tests/tests/widgets/keyboard.js
+++ b/static/script-tests/tests/widgets/keyboard.js
@@ -38,7 +38,7 @@
             });
 
     };
-
+    
     this.KeyboardTest.prototype.testStandardMultiTap = function (queue) {
         // Use JSON.parse/stringify to create a copy of the device config
         var config = JSON.parse(JSON.stringify(antie.framework.deviceConfiguration));
@@ -57,6 +57,9 @@
                 keyboard.fireEvent(new KeyEvent('keydown', KeyEvent.VK_2));
                 keyboard.fireEvent(new KeyEvent('keydown', KeyEvent.VK_2));
                 assertEquals('b', keyboard.getText());
+                assert(keyboard._letterButtons['b'].hasClass('active')); //check the button is active
+                assertFalse(keyboard._letterButtons['a'].hasClass('active')); //check the other buttons are not active
+                assertFalse(keyboard._letterButtons['c'].hasClass('active'));
             }, config);
     };
 
@@ -83,6 +86,31 @@
                 keyboard.fireEvent(new KeyEvent('keydown', KeyEvent.VK_2));
                 assertEquals('ba', keyboard.getText());
                 clock.restore();
+            }, config);
+    };
+
+    this.KeyboardTest.prototype.testDeleteKeyFocus = function (queue) {
+        // Use JSON.parse/stringify to create a copy of the device config
+        var config = JSON.parse(JSON.stringify(antie.framework.deviceConfiguration));
+        config.input.multitap = {
+            '2': ['a', 'b', 'c']
+        };
+        queuedApplicationInit(
+            queue,
+            'lib/mockapplication',
+            ['antie/widgets/keyboard', 'antie/events/keyevent'],
+            function(application, Keyboard, KeyEvent) {
+                var keyboard = new Keyboard('id', 1, 6, ['a','b','c','-']);
+                keyboard.setMultiTap(true);
+                keyboard.setCapitalisation(Keyboard.CAPITALISATION_LOWER);
+
+                keyboard.fireEvent(new KeyEvent('keydown', KeyEvent.VK_2));
+                keyboard.fireEvent(new KeyEvent('keydown', KeyEvent.VK_BACK_SPACE));
+                assertEquals('', keyboard.getText());
+                assert(keyboard._letterButtons['-'].hasClass('active')); //check the button is active
+                assertFalse(keyboard._letterButtons['a'].hasClass('active')); //check the other buttons are not active
+                assertFalse(keyboard._letterButtons['b'].hasClass('active'));
+                assertFalse(keyboard._letterButtons['c'].hasClass('active'));
             }, config);
     };
 

--- a/static/script/widgets/keyboard.js
+++ b/static/script/widgets/keyboard.js
@@ -179,6 +179,7 @@ define(
                     }
                 } else if(evt.keyCode === KeyEvent.VK_BACK_SPACE) {
                     if(this._currentText.length > 0) {
+                        this.setActiveChildKey('-');
                         this._currentText = this._currentText.substring(0, this._currentText.length - 1);
                         this._correctTitleCase();
 


### PR DESCRIPTION
… on the onscreen keyboard

Copied from 425:
Hi,
Triple tapping numbers on the remote control highlights the related keys (a-z, 0-9, SPACE) correctly.

However pressing 'delete' on the remote control does not highlight the DEL key onscreen.

I have a simple fix for this.
Inside keyboard, _onKeyDownHandler there is a separate case for VK_BACK_SPACE and I'm simply setting the active child key (exactly how it is done when you reach the maximum allowed length of input).

} else if(evt.keyCode === KeyEvent.VK_BACK_SPACE) {
    if(this._currentText.length > 0) {
        this.setActiveChildKey('-');
        ...

I think I have this (whole) line ready with some tests :)

Thanks,
Sam
