### PR TITLE
Add unit option in css3transform expansion modifier

### DIFF
--- a/static/script-tests/tests/devices/anim/css3transform.js
+++ b/static/script-tests/tests/devices/anim/css3transform.js
@@ -41,7 +41,6 @@ require(
                     },
                     {
                         name: 'tweenElementStyle',
-                        animatesAfterTick: true,
                         to: {
                             width: 666
                         }

--- a/static/script/devices/anim/css3transform/expand.js
+++ b/static/script/devices/anim/css3transform/expand.js
@@ -11,12 +11,14 @@ define(
             var el = options.el;
 
             function start () {
-                function setDimensions () {
-                    if (options.to.width) {
-                        Helpers.setStyle(el, 'width', options.to.width + 'px');
+                function setDimensions (dimensions, units) {
+                    dimensions = dimensions || {};
+
+                    if (dimensions.width !== undefined) {
+                        Helpers.setStyle(el, 'width', dimensions.width + (units ? units.width: 'px'));
                     }
-                    if (options.to.height) {
-                        Helpers.setStyle(el, 'height', options.to.height + 'px');
+                    if (dimensions.height !== undefined) {
+                        Helpers.setStyle(el, 'height', dimensions.height + (units ? units.height: 'px'));
                     }
                 }
 
@@ -33,12 +35,12 @@ define(
                     return;
                 }
 
+                setDimensions(options.from, options.units);
                 // Avoid the 'animate' class being overwritten by TAL if any widget-class methods are called after animating. Sigh...
-                setTimeout(function () {
-                    el.classList.add('animate');
-                    setDimensions();
-                    onTransitionEnd = Helpers.registerTransitionEndEvent(el, onComplete);
-                }, 0);
+                el.offsetHeight;
+                el.classList.add('animate');
+                setDimensions(options.to, options.units);
+                onTransitionEnd = Helpers.registerTransitionEndEvent(el, onComplete);
             }
 
             function stop () {

--- a/static/script/devices/anim/css3transform/expand.js
+++ b/static/script/devices/anim/css3transform/expand.js
@@ -30,7 +30,7 @@ define(
                 }
 
                 if (Helpers.skipAnim(options)) {
-                    setDimensions();
+                    setDimensions(options.to, options.units);
                     onComplete();
                     return;
                 }

--- a/static/script/devices/anim/css3transform/expand.js
+++ b/static/script/devices/anim/css3transform/expand.js
@@ -15,10 +15,10 @@ define(
                     dimensions = dimensions || {};
 
                     if (dimensions.width !== undefined) {
-                        Helpers.setStyle(el, 'width', dimensions.width + (units ? units.width: 'px'));
+                        Helpers.setStyle(el, 'width', dimensions.width + (units ? units.width : 'px'));
                     }
                     if (dimensions.height !== undefined) {
-                        Helpers.setStyle(el, 'height', dimensions.height + (units ? units.height: 'px'));
+                        Helpers.setStyle(el, 'height', dimensions.height + (units ? units.height : 'px'));
                     }
                 }
 
@@ -36,7 +36,7 @@ define(
                 }
 
                 setDimensions(options.from, options.units);
-                // Avoid the 'animate' class being overwritten by TAL if any widget-class methods are called after animating. Sigh...
+                // Force reflow so the 'from' values are applied before the 'to'
                 el.offsetHeight;
                 el.classList.add('animate');
                 setDimensions(options.to, options.units);


### PR DESCRIPTION
Allows the client to set optional units when using tweenElementStyle() in the css3transform animation modifier (as in the other modifiers).