### PR TITLE
Add async call in setChannelByName when currentChannelName is different.

### DIFF
--- a/static/script-tests/tests/devices/broadcastsource/tizentvsourcetest.js
+++ b/static/script-tests/tests/devices/broadcastsource/tizentvsourcetest.js
@@ -366,12 +366,13 @@
     };
 
     this.tizentvSource.prototype.testSetChannelByNameCallsOnSuccessIfChangingToCurrentChannel = function (queue) {
-        expectAsserts(2);
+        expectAsserts(3);
 
         var self = this;
         var config = getGenericTizenTVConfig();
         queuedApplicationInit(queue, 'lib/mockapplication', [], function (application) {
-
+            
+            var tizenApiSpyShow = self.sandbox.spy(tizen.tvwindow, 'show');
             var device = application.getDevice();
             var broadcastSource = device.createBroadcastSource();
 
@@ -379,12 +380,14 @@
                 channelName: 'BBC One',
                 onSuccess: self.sandbox.stub(),
                 onError: self.sandbox.stub()
-            };
+            };            
+            
+            broadcastSource.setChannelByName(params);   
+            tizenApiSpyShow.args[0][0]();
 
-            broadcastSource.setChannelByName(params);
-
-            assert(params.onSuccess.calledOnce);
+            assert(params.onSuccess.calledOnce);     
             assert(params.onError.notCalled);
+            assertTrue('Native Tizen show function called', tizenApiSpyShow.calledOnce);
         }, config);
     };
 
@@ -412,35 +415,13 @@
     };
 
     this.tizentvSource.prototype.testSetChannelByNameRetrievesChannelListWhenChangingToDifferentChannel = function (queue) {
-        expectAsserts(1);
-
-        var self = this;
-        var config = getGenericTizenTVConfig();
-        queuedApplicationInit(queue, 'lib/mockapplication', [], function (application) {
-            var tizenApiSpy = self.sandbox.spy(tizen.tvchannel, 'getChannelList');
-
-            var device = application.getDevice();
-            var broadcastSource = device.createBroadcastSource();
-
-            var params = {
-                channelName: 'BBC Two',
-                onSuccess: self.sandbox.stub(),
-                onError: self.sandbox.stub()
-            };
-
-            broadcastSource.setChannelByName(params);
-
-            assert(tizenApiSpy.calledOnce);
-        }, config);
-    };
-
-    this.tizentvSource.prototype.testSetChannelByNameCallsOnErrorWhenFailingToRetrieveChannelList = function (queue) {
         expectAsserts(2);
 
         var self = this;
         var config = getGenericTizenTVConfig();
         queuedApplicationInit(queue, 'lib/mockapplication', [], function (application) {
-            self.sandbox.stub(tizen.tvchannel, 'getChannelList').throwsException('Incorrect!');
+            var tizenApiSpy = self.sandbox.spy(tizen.tvchannel, 'getChannelList');
+            var tizenApiSpyShow = self.sandbox.spy(tizen.tvwindow, 'show');
 
             var device = application.getDevice();
             var broadcastSource = device.createBroadcastSource();
@@ -452,19 +433,48 @@
             };
 
             broadcastSource.setChannelByName(params);
+            tizenApiSpyShow.args[0][0]();
+
+            assert(tizenApiSpy.calledOnce);
+            assertTrue('Native Tizen show function called', tizenApiSpyShow.calledOnce);
+        }, config);
+    };
+
+    this.tizentvSource.prototype.testSetChannelByNameCallsOnErrorWhenFailingToRetrieveChannelList = function (queue) {
+        expectAsserts(3);
+
+        var self = this;
+        var config = getGenericTizenTVConfig();
+        queuedApplicationInit(queue, 'lib/mockapplication', [], function (application) {
+            self.sandbox.stub(tizen.tvchannel, 'getChannelList').throwsException('Incorrect!');
+            var tizenApiSpyShow = self.sandbox.spy(tizen.tvwindow, 'show');
+
+            var device = application.getDevice();
+            var broadcastSource = device.createBroadcastSource();
+
+            var params = {
+                channelName: 'BBC Two',
+                onSuccess: self.sandbox.stub(),
+                onError: self.sandbox.stub()
+            };
+
+            broadcastSource.setChannelByName(params);
+            tizenApiSpyShow.args[0][0]();
 
             assert(params.onSuccess.notCalled);
             assert(params.onError.calledOnce);
+            assertTrue('Native Tizen show function called', tizenApiSpyShow.calledOnce);
         }, config);
     };
 
     this.tizentvSource.prototype.testSetChannelByNameCallsOnErrorWhenChannelNotInChannelList = function (queue) {
-        expectAsserts(4);
+        expectAsserts(5);
 
         var self = this;
         var config = getGenericTizenTVConfig();
         queuedApplicationInit(queue, 'lib/mockapplication', [], function (application) {
             var tizenApiSpy = self.sandbox.spy(tizen.tvchannel, 'getChannelList');
+            var tizenApiSpyShow = self.sandbox.spy(tizen.tvwindow, 'show');
 
             var device = application.getDevice();
             var broadcastSource = device.createBroadcastSource();
@@ -475,8 +485,11 @@
                 onError: self.sandbox.stub()
             };
 
-            broadcastSource.setChannelByName(params);
+            broadcastSource.setChannelByName(params);            
+            tizenApiSpyShow.args[0][0]();
+            
             assert(tizenApiSpy.calledOnce);
+            assertTrue('Native Tizen show function called', tizenApiSpyShow.calledOnce);
 
             var getChannelListSuccesFunc = tizenApiSpy.args[0][0];
 
@@ -498,14 +511,15 @@
     };
 
     this.tizentvSource.prototype.testSetChannelByNameAttemptsToTuneToChannelInChannelList = function (queue) {
-        expectAsserts(8);
+        expectAsserts(9);
 
         var self = this;
         var config = getGenericTizenTVConfig();
         queuedApplicationInit(queue, 'lib/mockapplication', [], function (application) {
+            var tizenApiSpyShow = self.sandbox.spy(tizen.tvwindow, 'show');
             var getChannelListStub = self.sandbox.spy(tizen.tvchannel, 'getChannelList');
             var tuneSpy = self.sandbox.spy(tizen.tvchannel, 'tune');
-
+            
             var device = application.getDevice();
             var broadcastSource = device.createBroadcastSource();
 
@@ -514,12 +528,15 @@
                 onSuccess: self.sandbox.stub(),
                 onError: self.sandbox.stub()
             };
-
-            broadcastSource.setChannelByName(params);
+            
+            broadcastSource.setChannelByName(params);               
+            tizenApiSpyShow.args[0][0](); 
+            
             assert(getChannelListStub.calledOnce);
+            assertTrue('Native Tizen show function called', tizenApiSpyShow.calledOnce);
 
             var getChannelListSuccessFunc = getChannelListStub.args[0][0];
-
+           
             getChannelListSuccessFunc(
                 [
                     {
@@ -550,7 +567,7 @@
                 sourceID: 0,
                 transportStreamID: 3
             };
-
+            
             assertEquals(expectedTuneChannelObj, tuneSpy.args[0][0]);
             assertObject(tuneSpy.args[0][1]);
             assertFunction(tuneSpy.args[0][1].onsuccess);
@@ -561,13 +578,14 @@
     };
 
     this.tizentvSource.prototype.testSetChannelByNameCallsOnErrorIfTuneThrowsException = function (queue) {
-        expectAsserts(5);
+        expectAsserts(6);
 
         var self = this;
         var config = getGenericTizenTVConfig();
         queuedApplicationInit(queue, 'lib/mockapplication', [], function (application) {
             var getChannelListStub = self.sandbox.spy(tizen.tvchannel, 'getChannelList');
             var tuneStub = self.sandbox.stub(tizen.tvchannel, 'tune').throwsException('Incorrect!');
+            var tizenApiSpyShow = self.sandbox.spy(tizen.tvwindow, 'show');
 
             var device = application.getDevice();
             var broadcastSource = device.createBroadcastSource();
@@ -578,8 +596,11 @@
                 onError: self.sandbox.stub()
             };
 
-            broadcastSource.setChannelByName(params);
+            broadcastSource.setChannelByName(params);          
+            tizenApiSpyShow.args[0][0]();
+            
             assert(getChannelListStub.calledOnce);
+            assertTrue('Native Tizen show function called', tizenApiSpyShow.calledOnce);
 
             var getChannelListSuccessFunc = getChannelListStub.args[0][0];
 
@@ -610,13 +631,14 @@
     };
 
     this.tizentvSource.prototype.testSetChannelByNameCallsOnErrorIfTuneErrors = function (queue) {
-        expectAsserts(5);
+        expectAsserts(6);
 
         var self = this;
         var config = getGenericTizenTVConfig();
         queuedApplicationInit(queue, 'lib/mockapplication', [], function (application) {
             var getChannelListStub = self.sandbox.spy(tizen.tvchannel, 'getChannelList');
             var tuneSpy = self.sandbox.spy(tizen.tvchannel, 'tune');
+            var tizenApiSpyShow = self.sandbox.spy(tizen.tvwindow, 'show');
 
             var device = application.getDevice();
             var broadcastSource = device.createBroadcastSource();
@@ -628,7 +650,10 @@
             };
 
             broadcastSource.setChannelByName(params);
+            tizenApiSpyShow.args[0][0]();
+            
             assert(getChannelListStub.calledOnce);
+            assertTrue('Native Tizen show function called', tizenApiSpyShow.calledOnce);
 
             var getChannelListSuccessFunc = getChannelListStub.args[0][0];
 
@@ -664,13 +689,14 @@
     };
 
     this.tizentvSource.prototype.testSetChannelByNameCallsOnSuccessIfTuneSucceeds = function (queue) {
-        expectAsserts(4);
+        expectAsserts(5);
 
         var self = this;
         var config = getGenericTizenTVConfig();
         queuedApplicationInit(queue, 'lib/mockapplication', [], function (application) {
             var getChannelListStub = self.sandbox.spy(tizen.tvchannel, 'getChannelList');
             var tuneSpy = self.sandbox.spy(tizen.tvchannel, 'tune');
+            var tizenApiSpyShow = self.sandbox.spy(tizen.tvwindow, 'show');
 
             var device = application.getDevice();
             var broadcastSource = device.createBroadcastSource();
@@ -682,7 +708,10 @@
             };
 
             broadcastSource.setChannelByName(params);
+            tizenApiSpyShow.args[0][0]();
+            
             assert(getChannelListStub.calledOnce);
+            assertTrue('Native Tizen show function called', tizenApiSpyShow.calledOnce);
 
             var getChannelListSuccessFunc = getChannelListStub.args[0][0];
 

--- a/static/script/devices/broadcastsource/tizentvsource.js
+++ b/static/script/devices/broadcastsource/tizentvsource.js
@@ -106,8 +106,8 @@ define(
              * Shows current channel by setting broadcast source to full screen
              * @override
              */
-            showCurrentChannel: function () {
-                this._setBroadcastToFullScreen();
+            showCurrentChannel: function (callback) {
+                this._setBroadcastToFullScreen(callback);
             },
 
             /**
@@ -178,12 +178,15 @@ define(
              * @param width
              * @param height
              */
-            setPosition: function (top, left, width, height) {
+            setPosition: function (top, left, width, height, callback) {
                 var self = this;
-
+                
                 tizen.tvwindow.show(
                     function () {
                         self.setState(BaseTvSource.STATE.PRESENTING);
+                        if (typeof callback === 'function') {
+                            callback();
+                        }
                     },
                     this.nop,
                     [left, top, width, height],
@@ -210,17 +213,20 @@ define(
             setChannelByName: function (params) {
                 params.onSuccess = params.onSuccess || this.nop;
                 params.onError = params.onError || this.nop;
+                
+                var self = this;
 
                 try {
                     var currentChannelName = this.getCurrentChannelName();
                     if (currentChannelName === params.channelName) {
-                        this.showCurrentChannel();
-                        params.onSuccess();
-                    } else {
-                        this._tuneToChannelByName({
-                            name: params.channelName,
-                            onError: params.onError,
-                            onSuccess: params.onSuccess
+                        this.showCurrentChannel(params.onSuccess);
+                    } else {    
+                        this.showCurrentChannel(function() {
+                            self._tuneToChannelByName({
+                                name: params.channelName,
+                                onError: params.onError,
+                                onSuccess: params.onSuccess
+                            });
                         });
                     }
                 } catch (error) {
@@ -231,11 +237,11 @@ define(
                 }
             },
 
-            _setBroadcastToFullScreen: function () {
-                this.setPosition(0, 0, window.screen.width, window.screen.height);
+            _setBroadcastToFullScreen: function (callback) {
+                this.setPosition(0, 0, window.screen.width, window.screen.height, callback);
             },
 
-            _tuneToChannelByName: function (params) {
+            _tuneToChannelByName: function (params) {                
                 params.onSuccess = params.onSuccess || this.nop;
                 params.onError = params.onError || this.nop;
 


### PR DESCRIPTION
Synchronous call won't work if channel is different, so async call is required.
For callback handling new param support was added to below methods: showCurrentChannel(), setPosition(), _setBroadcastToFullScreen().
For Unit Tests purpose, test methods were updated and extended by new tizen.tvwindow.show API call.