### PR TITLE
2014 live seek final implementation

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,4 +7,3 @@ static/script-tests/lib/*
 static/script-tests/jasmine/*
 static/script-tests/fixtures/*
 static/script-tests/api/*
-static/script/devices/mediaplayer/samsung_streaming.js

--- a/static/script-tests/tests/devices/mediaplayer/samsung_streaming.js
+++ b/static/script-tests/tests/devices/mediaplayer/samsung_streaming.js
@@ -152,7 +152,7 @@
     };
 
     //---------------------
-    // Samsung Maple specific tests
+    // Samsung Streaming specific tests
     //---------------------
     
     var listenerEventCodes = {

--- a/static/script-tests/tests/devices/mediaplayer/samsung_streaming.js
+++ b/static/script-tests/tests/devices/mediaplayer/samsung_streaming.js
@@ -4,7 +4,6 @@
  */
 
 (function() {
-    var self = this;
     this.SamsungStreamingMediaPlayerTests = AsyncTestCase('SamsungStreamingMediaPlayer');
 
     var config = {'modules':{'base':'antie/devices/browserdevice','modifiers':['antie/devices/mediaplayer/samsung_streaming']}, 'input':{'map':{}},'layouts':[{'width':960,'height':540,'module':'fixtures/layouts/default','classes':['browserdevice540p']}],'deviceConfigurationKey':'devices-html5-1'};
@@ -76,23 +75,23 @@
             Open: this.sandbox.stub(),
             Execute: function(command) {
                 switch (command) {
-                    case "InitPlayer":
+                    case 'InitPlayer':
                         return this._methods.InitPlayer(arguments[1]);
-                    case "StartPlayback":
+                    case 'StartPlayback':
                         return this._methods.StartPlayback(arguments[1]);
-                    case "JumpForward":
+                    case 'JumpForward':
                         return this._methods.JumpForward(arguments[1]);
-                    case "JumpBackward":
+                    case 'JumpBackward':
                         return this._methods.JumpBackward(arguments[1]);
-                    case "Pause":
+                    case 'Pause':
                         return this._methods.Pause();
-                    case "Resume":
+                    case 'Resume':
                         return this._methods.Resume();
-                    case "Stop":
+                    case 'Stop':
                         return this._methods.Stop();
-                    case "GetDuration":
+                    case 'GetDuration':
                         return this._methods.GetDuration();
-                    case "GetPlayingRange":
+                    case 'GetPlayingRange':
                         return this._methods.GetPlayingRange();
                     default:
                         return -1;
@@ -122,7 +121,7 @@
         playerPlugin._methods.Pause.returns(1);
         playerPlugin._methods.Resume.returns(1);
         playerPlugin._methods.Stop.returns(1);
-        playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + "-" + playerPlugin._range.end);
+        playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + '-' + playerPlugin._range.end);
         playerPlugin._methods.GetDuration.returns(playerPlugin._range.end * 1000);
 
         var originalGetElementById = document.getElementById;
@@ -259,13 +258,14 @@
     };
     
     
-    /*HLS specific tests START*/   this.SamsungStreamingMediaPlayerTests.prototype.testPLayerOpenPluginThenHlsStartPlaybackCalledOnDeviceWhenBeginPlaybackFromCalledInStoppedState = function(queue) {
+    /*HLS specific tests START*/
+    this.SamsungStreamingMediaPlayerTests.prototype.testPLayerOpenPluginThenHlsStartPlaybackCalledOnDeviceWhenBeginPlaybackFromCalledInStoppedState = function(queue) {
         expectAsserts(9);
         runMediaPlayerTest(this, queue, function(MediaPlayer) {
             assert(playerPlugin.Open.notCalled);
             assert(playerPlugin._methods.InitPlayer.notCalled);
             this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'application/vnd.apple.mpegurl');
-            assert(playerPlugin.Open.calledWith("Player", "1.010", "Player"));
+            assert(playerPlugin.Open.calledWith('Player', '1.010', 'Player'));
             assert(playerPlugin.Open.calledOnce);
             assert(playerPlugin._methods.InitPlayer.calledWith('testURL|COMPONENT=HLS'));
             assert(playerPlugin._methods.InitPlayer.calledOnce);
@@ -275,14 +275,14 @@
             assert(playerPlugin._methods.StartPlayback.calledWith(0));
             assert(playerPlugin._methods.StartPlayback.calledOnce);
         });
-   }; 
-   this.SamsungStreamingMediaPlayerTests.prototype.testPLayerOpenPluginThenHlsPlayCalledOnDeviceWhenBeginPlaybackFromCalledInStoppedState = function(queue) {
+   };
+    this.SamsungStreamingMediaPlayerTests.prototype.testPLayerOpenPluginThenHlsPlayCalledOnDeviceWhenBeginPlaybackFromCalledInStoppedState = function(queue) {
         expectAsserts(8);
         runMediaPlayerTest(this, queue, function(MediaPlayer) {
             assert(playerPlugin.Open.notCalled);
             assert(playerPlugin._methods.InitPlayer.notCalled);
             this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'application/vnd.apple.mpegurl');
-            assert(playerPlugin.Open.calledWith("Player", "1.010", "Player"));
+            assert(playerPlugin.Open.calledWith('Player', '1.010', 'Player'));
             assert(playerPlugin.Open.calledOnce);
             assert(playerPlugin._methods.InitPlayer.calledWith('testURL|COMPONENT=HLS'));
             assert(playerPlugin._methods.InitPlayer.calledOnce);
@@ -299,7 +299,7 @@
             assert(playerPlugin.Open.notCalled);
             assert(playerPlugin._methods.InitPlayer.notCalled);
             this._mediaPlayer.setSource(MediaPlayer.TYPE.LIVE_VIDEO, 'testURL', 'application/vnd.apple.mpegurl');
-            assert(playerPlugin.Open.calledWith("StreamingPlayer", "1.0", "StreamingPlayer"));
+            assert(playerPlugin.Open.calledWith('StreamingPlayer', '1.0', 'StreamingPlayer'));
             assert(playerPlugin.Open.calledOnce);
             assert(playerPlugin._methods.InitPlayer.calledWith('testURL|HLSSLIDING|COMPONENT=HLS'));
             assert(playerPlugin._methods.InitPlayer.calledOnce);
@@ -315,7 +315,7 @@
             assert(playerPlugin.Open.notCalled);
             assert(playerPlugin._methods.InitPlayer.notCalled);
             this._mediaPlayer.setSource(MediaPlayer.TYPE.LIVE_VIDEO, 'testURL', 'application/vnd.apple.mpegurl');
-            assert(playerPlugin.Open.calledWith("StreamingPlayer", "1.0", "StreamingPlayer"));
+            assert(playerPlugin.Open.calledWith('StreamingPlayer', '1.0', 'StreamingPlayer'));
             assert(playerPlugin.Open.calledOnce);
             assert(playerPlugin._methods.InitPlayer.calledWith('testURL|HLSSLIDING|COMPONENT=HLS'));
             assert(playerPlugin._methods.InitPlayer.calledOnce);
@@ -332,7 +332,7 @@
             assert(playerPlugin.Open.notCalled);
             assert(playerPlugin._methods.InitPlayer.notCalled);
             this._mediaPlayer.setSource(MediaPlayer.TYPE.LIVE_VIDEO, 'testURL', 'application/vnd.apple.mpegurl');
-            assert(playerPlugin.Open.calledWith("StreamingPlayer", "1.0", "StreamingPlayer"));
+            assert(playerPlugin.Open.calledWith('StreamingPlayer', '1.0', 'StreamingPlayer'));
             assert(playerPlugin.Open.calledOnce);
             assert(playerPlugin._methods.InitPlayer.calledWith('testURL|HLSSLIDING|COMPONENT=HLS'));
             assert(playerPlugin._methods.InitPlayer.calledOnce);
@@ -341,7 +341,7 @@
             this._mediaPlayer.beginPlaybackFrom(0);
             assert(playerPlugin._methods.StartPlayback.calledOnce);
             //live playback started from 0 position causes spoiler defect
-            assertEquals(this._mediaPlayer.CLAMP_OFFSET_FROM_END_OF_RANGE, playerPlugin._methods.StartPlayback.args[0][0]);
+            assertEquals(this._mediaPlayer.CLAMP_OFFSET_FROM_START_OF_RANGE, playerPlugin._methods.StartPlayback.args[0][0]);
         });
     };
     
@@ -351,7 +351,7 @@
             assert(playerPlugin.Open.notCalled);
             assert(playerPlugin._methods.InitPlayer.notCalled);
             this._mediaPlayer.setSource(MediaPlayer.TYPE.LIVE_VIDEO, 'testURL', 'application/vnd.apple.mpegurl');
-            assert(playerPlugin.Open.calledWith("StreamingPlayer", "1.0", "StreamingPlayer"));
+            assert(playerPlugin.Open.calledWith('StreamingPlayer', '1.0', 'StreamingPlayer'));
             assert(playerPlugin.Open.calledOnce);
             assert(playerPlugin._methods.InitPlayer.calledWith('testURL|HLSSLIDING|COMPONENT=HLS'));
             assert(playerPlugin._methods.InitPlayer.calledOnce);
@@ -372,7 +372,7 @@
             deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 100 });
             deviceMockingHooks.finishBuffering(this._mediaPlayer);
             playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 0);
-            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + "-" + playerPlugin._range.end);
+            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + '-' + playerPlugin._range.end);
             this._mediaPlayer._updatingTime = false;
             
             assert(playerPlugin._methods.InitPlayer.calledOnce);
@@ -384,7 +384,7 @@
                 end: 124
             };
             playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 22 * 1000);
-            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + "-" + playerPlugin._range.end);
+            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + '-' + playerPlugin._range.end);
             
             assert(playerPlugin._methods.JumpForward.notCalled);
             this._mediaPlayer.playFrom(50);
@@ -403,7 +403,7 @@
             deviceMockingHooks.sendMetadata(this._mediaPlayer, 100, { start: 0, end: 100 });
             deviceMockingHooks.finishBuffering(this._mediaPlayer);
             playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 90 * 1000);
-            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + "-" + playerPlugin._range.end);
+            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + '-' + playerPlugin._range.end);
             this._mediaPlayer._updatingTime = false;
             
             assert(playerPlugin._methods.InitPlayer.calledOnce);
@@ -415,7 +415,7 @@
                 end: 124
             };
             playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 122 * 1000);
-            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + "-" + playerPlugin._range.end);
+            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + '-' + playerPlugin._range.end);
             
             assert(playerPlugin._methods.JumpBackward.notCalled);
             this._mediaPlayer.playFrom(10);
@@ -455,7 +455,7 @@
             this._mediaPlayer.beginPlayback();
             deviceMockingHooks.sendMetadata(this._mediaPlayer, 100, { start: 0, end: 100 });
             playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 100 * 1000);
-            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + "-" + playerPlugin._range.end);
+            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + '-' + playerPlugin._range.end);
             deviceMockingHooks.finishBuffering(this._mediaPlayer);
             
             assert(playerPlugin._methods.GetPlayingRange.calledOnce);
@@ -466,7 +466,7 @@
                 end: 124
             };
             playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 133 * 1000);
-            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + "-" + playerPlugin._range.end);
+            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + '-' + playerPlugin._range.end);
             
             assertEquals(this._mediaPlayer_range, playerPlugin._methods.GetPlayingRange.args[1][0]);
             assert(playerPlugin._methods.GetPlayingRange.calledTwice);
@@ -482,7 +482,7 @@
             deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 100 });
             deviceMockingHooks.finishBuffering(this._mediaPlayer);
             playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME,  this._mediaPlayer.CLAMP_OFFSET_FROM_END_OF_RANGE * 1000);
-            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + "-" + playerPlugin._range.end);
+            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + '-' + playerPlugin._range.end);
             
             assert(playerPlugin._methods.GetPlayingRange.calledOnce);
             this._mediaPlayer._updatingTime = false;
@@ -492,7 +492,7 @@
                 end: 124
             };
             playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 15 * 1000);
-            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + "-" + playerPlugin._range.end);
+            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + '-' + playerPlugin._range.end);
             
             assertEquals(this._mediaPlayer_range, playerPlugin._methods.GetPlayingRange.args[1][0]);
             assert(playerPlugin._methods.GetPlayingRange.calledTwice);
@@ -533,7 +533,7 @@
             
             assert(eventHandler.calledTwice);
             assertEquals(MediaPlayer.EVENT.ERROR, eventHandler.args[1][0].type);
-            assertEquals("Failed to initialize video: testUrl", eventHandler.args[1][0].errorMessage);
+            assertEquals('Failed to initialize video: testUrl', eventHandler.args[1][0].errorMessage);
         });
     };
 
@@ -543,7 +543,7 @@
             assert(playerPlugin.Open.notCalled);
             assert(playerPlugin._methods.InitPlayer.notCalled);
             this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
-            assert(playerPlugin.Open.calledWith("Player", "1.010", "Player"));
+            assert(playerPlugin.Open.calledWith('Player', '1.010', 'Player'));
             assert(playerPlugin.Open.calledOnce);
             assert(playerPlugin._methods.InitPlayer.calledWith('testURL'));
             assert(playerPlugin._methods.InitPlayer.calledOnce);
@@ -561,7 +561,7 @@
             assert(playerPlugin.Open.notCalled);
             assert(playerPlugin._methods.InitPlayer.notCalled);
             this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
-            assert(playerPlugin.Open.calledWith("Player", "1.010", "Player"));
+            assert(playerPlugin.Open.calledWith('Player', '1.010', 'Player'));
             assert(playerPlugin.Open.calledOnce);
             assert(playerPlugin._methods.InitPlayer.calledWith('testURL'));
             assert(playerPlugin._methods.InitPlayer.calledOnce);
@@ -594,7 +594,7 @@
             assert(playerPlugin.Open.notCalled);
             assert(playerPlugin._methods.InitPlayer.notCalled);
             this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
-            assert(playerPlugin.Open.calledWith("Player", "1.010", "Player"));
+            assert(playerPlugin.Open.calledWith('Player', '1.010', 'Player'));
             assert(playerPlugin.Open.calledOnce);
             assert(playerPlugin._methods.InitPlayer.calledWith('testURL'));
             assert(playerPlugin._methods.InitPlayer.calledOnce);
@@ -1193,7 +1193,7 @@
 
             assert(playerPlugin._methods.Stop.called);
             assert(playerPlugin._methods.StartPlayback.calledTwice);
-            debugger;assertEquals(58.9, playerPlugin._methods.StartPlayback.args[1][0]);
+            assertEquals(58.9, playerPlugin._methods.StartPlayback.args[1][0]);
         });
     };
 

--- a/static/script-tests/tests/devices/mediaplayer/samsung_streaming.js
+++ b/static/script-tests/tests/devices/mediaplayer/samsung_streaming.js
@@ -75,26 +75,26 @@
             Open: this.sandbox.stub(),
             Execute: function(command) {
                 switch (command) {
-                    case 'InitPlayer':
-                        return this._methods.InitPlayer(arguments[1]);
-                    case 'StartPlayback':
-                        return this._methods.StartPlayback(arguments[1]);
-                    case 'JumpForward':
-                        return this._methods.JumpForward(arguments[1]);
-                    case 'JumpBackward':
-                        return this._methods.JumpBackward(arguments[1]);
-                    case 'Pause':
-                        return this._methods.Pause();
-                    case 'Resume':
-                        return this._methods.Resume();
-                    case 'Stop':
-                        return this._methods.Stop();
-                    case 'GetDuration':
-                        return this._methods.GetDuration();
-                    case 'GetPlayingRange':
-                        return this._methods.GetPlayingRange();
-                    default:
-                        return -1;
+                case 'InitPlayer':
+                    return this._methods.InitPlayer(arguments[1]);
+                case 'StartPlayback':
+                    return this._methods.StartPlayback(arguments[1]);
+                case 'JumpForward':
+                    return this._methods.JumpForward(arguments[1]);
+                case 'JumpBackward':
+                    return this._methods.JumpBackward(arguments[1]);
+                case 'Pause':
+                    return this._methods.Pause();
+                case 'Resume':
+                    return this._methods.Resume();
+                case 'Stop':
+                    return this._methods.Stop();
+                case 'GetDuration':
+                    return this._methods.GetDuration();
+                case 'GetPlayingRange':
+                    return this._methods.GetPlayingRange();
+                default:
+                    return -1;
                 }
             },
             Close: this.sandbox.stub(),
@@ -275,7 +275,7 @@
             assert(playerPlugin._methods.StartPlayback.calledWith(0));
             assert(playerPlugin._methods.StartPlayback.calledOnce);
         });
-   };
+    };
     this.SamsungStreamingMediaPlayerTests.prototype.testPLayerOpenPluginThenHlsPlayCalledOnDeviceWhenBeginPlaybackFromCalledInStoppedState = function(queue) {
         expectAsserts(8);
         runMediaPlayerTest(this, queue, function(MediaPlayer) {
@@ -308,8 +308,8 @@
             this._mediaPlayer.beginPlaybackFrom(0);
             assert(playerPlugin._methods.StartPlayback.calledOnce);
         });
-   }; 
-   this.SamsungStreamingMediaPlayerTests.prototype.testStreamingPLayerOpenPluginThenHlsLivePlayCalledOnDeviceWhenBeginPlaybackFromCalledInStoppedState = function(queue) {
+    }; 
+    this.SamsungStreamingMediaPlayerTests.prototype.testStreamingPLayerOpenPluginThenHlsLivePlayCalledOnDeviceWhenBeginPlaybackFromCalledInStoppedState = function(queue) {
         expectAsserts(8);
         runMediaPlayerTest(this, queue, function(MediaPlayer) {
             assert(playerPlugin.Open.notCalled);

--- a/static/script-tests/tests/devices/mediaplayer/samsung_streaming.js
+++ b/static/script-tests/tests/devices/mediaplayer/samsung_streaming.js
@@ -1,0 +1,1978 @@
+/**
+ * @preserve Copyright (c) 2013-present British Broadcasting Corporation. All rights reserved.
+ * @license See https://github.com/fmtvp/tal/blob/master/LICENSE for full licence
+ */
+
+(function() {
+    var self = this;
+    this.SamsungStreamingMediaPlayerTests = AsyncTestCase('SamsungStreamingMediaPlayer');
+
+    var config = {'modules':{'base':'antie/devices/browserdevice','modifiers':['antie/devices/mediaplayer/samsung_streaming']}, 'input':{'map':{}},'layouts':[{'width':960,'height':540,'module':'fixtures/layouts/default','classes':['browserdevice540p']}],'deviceConfigurationKey':'devices-html5-1'};
+    var screenSize = {};
+    var playerPlugin = null;
+
+    // Setup device specific mocking
+    var deviceMockingHooks = {
+        setup: function(/*sandbox, application*/) {
+
+            // Override StartPlayback to update the time for the common tests only - although the Samsung specific tests
+            // do use these mocking hooks, they do not call setup.
+            playerPlugin._methods.StartPlayback = function (seconds) {
+                this.parent._methods.GetDuration = function () {
+                    return this.parent._range.end * 1000;
+                };
+                this.parent.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, seconds * 1000);
+            };
+        },
+        sendMetadata: function(mediaPlayer, currentTime, range) {
+            if (range !== undefined) {
+                playerPlugin._range = range;
+            }
+            if (playerPlugin.OnEvent) {
+                playerPlugin.OnEvent(listenerEventCodes.STREAM_INFO_READY);
+            }
+        },
+        finishBuffering: function(/*mediaPlayer*/) {
+            if (playerPlugin.OnEvent) {
+                playerPlugin.OnEvent(listenerEventCodes.BUFFERING_COMPLETE);
+            }
+        },
+        emitPlaybackError: function(/*mediaPlayer*/) {
+            playerPlugin.OnEvent(listenerEventCodes.RENDER_ERROR);
+        },
+        reachEndOfMedia: function(mediaPlayer) {
+            if (playerPlugin.OnEvent) {
+                playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, mediaPlayer.getSeekableRange().end * 1000);
+                playerPlugin.OnEvent(listenerEventCodes.RENDERING_COMPLETE);
+            }
+        },
+        startBuffering: function(/*mediaPlayer*/) {
+            playerPlugin.OnEvent(listenerEventCodes.BUFFERING_START);
+            playerPlugin.OnEvent(listenerEventCodes.BUFFERING_PROGRESS);
+        },
+        mockTime: function(/*mediaplayer*/) {
+        },
+        makeOneSecondPass: function(mediaplayer) {
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, (mediaplayer.getCurrentTime() + 1) * 1000);
+        },
+        unmockTime: function(/*mediaplayer*/) {
+        }
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.setUp = function() {
+        this.sandbox = sinon.sandbox.create();
+
+        playerPlugin = {
+            self: this,
+            _range: {
+                start: 0,
+                end: 100
+            },
+            init : function() {
+                this._methods.parent = this;
+                delete this.init;
+                return this;
+            },
+            Open: this.sandbox.stub(),
+            Execute: function(command) {
+                switch (command) {
+                    case "InitPlayer":
+                        return this._methods.InitPlayer(arguments[1]);
+                    case "StartPlayback":
+                        return this._methods.StartPlayback(arguments[1]);
+                    case "JumpForward":
+                        return this._methods.JumpForward(arguments[1]);
+                    case "JumpBackward":
+                        return this._methods.JumpBackward(arguments[1]);
+                    case "Pause":
+                        return this._methods.Pause();
+                    case "Resume":
+                        return this._methods.Resume();
+                    case "Stop":
+                        return this._methods.Stop();
+                    case "GetDuration":
+                        return this._methods.GetDuration();
+                    case "GetPlayingRange":
+                        return this._methods.GetPlayingRange();
+                    default:
+                        return -1;
+                }
+            },
+            Close: this.sandbox.stub(),
+            OnEvent: undefined,
+            _methods: {
+                InitPlayer: this.sandbox.stub(),
+                StartPlayback: this.sandbox.stub(),
+                JumpForward: this.sandbox.stub(),
+                JumpBackward: this.sandbox.stub(),
+                Pause: this.sandbox.stub(),
+                Resume: this.sandbox.stub(),
+                Stop: this.sandbox.stub(),
+                GetPlayingRange: this.sandbox.stub(),
+                GetDuration: this.sandbox.stub()
+            }
+        }.init();
+
+        playerPlugin.Open.returns(1);
+        playerPlugin.Close.returns(1);
+        playerPlugin._methods.InitPlayer.returns(1);
+        playerPlugin._methods.StartPlayback.returns(1);
+        playerPlugin._methods.JumpForward.returns(1);
+        playerPlugin._methods.JumpBackward.returns(1);
+        playerPlugin._methods.Pause.returns(1);
+        playerPlugin._methods.Resume.returns(1);
+        playerPlugin._methods.Stop.returns(1);
+        playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + "-" + playerPlugin._range.end);
+        playerPlugin._methods.GetDuration.returns(playerPlugin._range.end * 1000);
+
+        var originalGetElementById = document.getElementById;
+        this.sandbox.stub(document, 'getElementById', function(id) {
+            switch(id) {
+            case 'sefPlayer':
+                return playerPlugin;
+            default:
+                return originalGetElementById.call(document, id);
+            }
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.tearDown = function() {
+        this.sandbox.restore();
+    };
+
+    var runMediaPlayerTest = function (self, queue, action) {
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/mediaplayer/samsung_streaming', 'antie/devices/mediaplayer/mediaplayer'],
+                              function(application, MediaPlayerImpl, MediaPlayer) {
+                                  self._device = application.getDevice();
+                                  self.sandbox.stub(self._device, 'getScreenSize').returns(screenSize);
+                                  self._errorLog = self.sandbox.stub(self._device.getLogger(), 'error');
+                                  self._mediaPlayer = self._device.getMediaPlayer();
+            
+                                  action.call(self, MediaPlayer);
+                              }, config);
+    };
+
+    //---------------------
+    // Samsung Maple specific tests
+    //---------------------
+    
+    var listenerEventCodes = {
+        CONNECTION_FAILED : 1,
+        AUTHENTICATION_FAILED : 2,
+        STREAM_NOT_FOUND : 3,
+        NETWORK_DISCONNECTED : 4,
+        RENDER_ERROR : 6,
+        RENDERING_START : 7,
+        RENDERING_COMPLETE : 8,
+        STREAM_INFO_READY : 9,
+        DECODING_COMPLETE : 10,
+        BUFFERING_START : 11,
+        BUFFERING_COMPLETE : 12,
+        BUFFERING_PROGRESS : 13,
+        CURRENT_PLAYBACK_TIME : 14
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testSamsungMapleListenerFunctionsAddedDuringSetSource = function(queue) {
+        expectAsserts(2);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            
+            assertUndefined('Expecting playerPlaugin.OnEvent to be undefined', playerPlugin.OnEvent);
+
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
+
+            assertFunction('Expecting playerPlaugin.OnEvent to be function', playerPlugin.OnEvent);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testSamsungMapleListenerFunctionsRemovedOnTransitionToErrorState = function(queue) {
+        expectAsserts(2);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
+
+            assertFunction('Expecting playerPlaugin.OnEvent to be function', playerPlugin.OnEvent);
+
+            try {
+                this._mediaPlayer.pause();
+            } catch (e) {}
+
+            assertUndefined('Expecting playerPlaugin.OnEvent to be undefined', playerPlugin.OnEvent);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testSamsungMapleListenerFunctionsRemovedOnReset = function(queue) {
+        expectAsserts(2);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
+
+            assertFunction('Expecting playerPlaugin.OnEvent to be function', playerPlugin.OnEvent);
+
+            this._mediaPlayer.reset();
+
+            assertUndefined('Expecting playerPlaugin.OnEvent to be undefined', playerPlugin.OnEvent);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testSamsungMapleListenerFunctionsReferencedOnObjectDuringSetSource = function(queue) {
+        expectAsserts(2);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+
+            assertUndefined(playerPlugin['OnEvent']);
+
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
+            
+            assertFunction(playerPlugin['OnEvent']);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testSamsungMapleListenerFunctionReferencesOnObjectRemovedOnTransiitonToErrorState = function(queue) {
+        expectAsserts(2);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
+
+            assertFunction(playerPlugin['OnEvent']);
+
+            try {
+                this._mediaPlayer.pause();
+            } catch (e) {}
+
+            assertUndefined(playerPlugin['OnEvent']);
+
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testSamsungMapleListenerFunctionReferencesOnObjectRemovedOnReset = function(queue) {
+        expectAsserts(2);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
+
+            assertFunction(playerPlugin['OnEvent']);
+
+            this._mediaPlayer.reset();
+
+            assertUndefined(playerPlugin['OnEvent']);
+
+        });
+    };
+    
+    
+    /*HLS specific tests START*/   this.SamsungStreamingMediaPlayerTests.prototype.testPLayerOpenPluginThenHlsStartPlaybackCalledOnDeviceWhenBeginPlaybackFromCalledInStoppedState = function(queue) {
+        expectAsserts(9);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            assert(playerPlugin.Open.notCalled);
+            assert(playerPlugin._methods.InitPlayer.notCalled);
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'application/vnd.apple.mpegurl');
+            assert(playerPlugin.Open.calledWith("Player", "1.010", "Player"));
+            assert(playerPlugin.Open.calledOnce);
+            assert(playerPlugin._methods.InitPlayer.calledWith('testURL|COMPONENT=HLS'));
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            
+            assert(playerPlugin._methods.StartPlayback.notCalled);
+            this._mediaPlayer.beginPlaybackFrom(0);
+            assert(playerPlugin._methods.StartPlayback.calledWith(0));
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+        });
+   }; 
+   this.SamsungStreamingMediaPlayerTests.prototype.testPLayerOpenPluginThenHlsPlayCalledOnDeviceWhenBeginPlaybackFromCalledInStoppedState = function(queue) {
+        expectAsserts(8);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            assert(playerPlugin.Open.notCalled);
+            assert(playerPlugin._methods.InitPlayer.notCalled);
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'application/vnd.apple.mpegurl');
+            assert(playerPlugin.Open.calledWith("Player", "1.010", "Player"));
+            assert(playerPlugin.Open.calledOnce);
+            assert(playerPlugin._methods.InitPlayer.calledWith('testURL|COMPONENT=HLS'));
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            
+            assert(playerPlugin._methods.StartPlayback.notCalled);
+            this._mediaPlayer.beginPlayback();
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testStreamingPLayerOpenPluginThenHlsLiveStartPlaybackCalledOnDeviceWhenBeginPlaybackFromCalledInStoppedState = function(queue) {
+        expectAsserts(8);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            assert(playerPlugin.Open.notCalled);
+            assert(playerPlugin._methods.InitPlayer.notCalled);
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.LIVE_VIDEO, 'testURL', 'application/vnd.apple.mpegurl');
+            assert(playerPlugin.Open.calledWith("StreamingPlayer", "1.0", "StreamingPlayer"));
+            assert(playerPlugin.Open.calledOnce);
+            assert(playerPlugin._methods.InitPlayer.calledWith('testURL|HLSSLIDING|COMPONENT=HLS'));
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            
+            assert(playerPlugin._methods.StartPlayback.notCalled);
+            this._mediaPlayer.beginPlaybackFrom(0);
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+        });
+   }; 
+   this.SamsungStreamingMediaPlayerTests.prototype.testStreamingPLayerOpenPluginThenHlsLivePlayCalledOnDeviceWhenBeginPlaybackFromCalledInStoppedState = function(queue) {
+        expectAsserts(8);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            assert(playerPlugin.Open.notCalled);
+            assert(playerPlugin._methods.InitPlayer.notCalled);
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.LIVE_VIDEO, 'testURL', 'application/vnd.apple.mpegurl');
+            assert(playerPlugin.Open.calledWith("StreamingPlayer", "1.0", "StreamingPlayer"));
+            assert(playerPlugin.Open.calledOnce);
+            assert(playerPlugin._methods.InitPlayer.calledWith('testURL|HLSSLIDING|COMPONENT=HLS'));
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            
+            assert(playerPlugin._methods.StartPlayback.notCalled);
+            this._mediaPlayer.beginPlayback();
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testHlsLiveStartPlaybackFromBeginingCalledOnDeviceWhenBeginPlaybackFromCalledInStoppedState = function(queue) {
+        expectAsserts(9);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            assert(playerPlugin.Open.notCalled);
+            assert(playerPlugin._methods.InitPlayer.notCalled);
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.LIVE_VIDEO, 'testURL', 'application/vnd.apple.mpegurl');
+            assert(playerPlugin.Open.calledWith("StreamingPlayer", "1.0", "StreamingPlayer"));
+            assert(playerPlugin.Open.calledOnce);
+            assert(playerPlugin._methods.InitPlayer.calledWith('testURL|HLSSLIDING|COMPONENT=HLS'));
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            
+            assert(playerPlugin._methods.StartPlayback.notCalled);
+            this._mediaPlayer.beginPlaybackFrom(0);
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+            //live playback started from 0 position causes spoiler defect
+            assertEquals(this._mediaPlayer.CLAMP_OFFSET_FROM_END_OF_RANGE, playerPlugin._methods.StartPlayback.args[0][0]);
+        });
+    };
+    
+    this.SamsungStreamingMediaPlayerTests.prototype.testHlsLiveResumePlayCalledWithTimePassedIntoBeginPlaybackFrom = function(queue) {
+        expectAsserts(9);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            assert(playerPlugin.Open.notCalled);
+            assert(playerPlugin._methods.InitPlayer.notCalled);
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.LIVE_VIDEO, 'testURL', 'application/vnd.apple.mpegurl');
+            assert(playerPlugin.Open.calledWith("StreamingPlayer", "1.0", "StreamingPlayer"));
+            assert(playerPlugin.Open.calledOnce);
+            assert(playerPlugin._methods.InitPlayer.calledWith('testURL|HLSSLIDING|COMPONENT=HLS'));
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            
+            assert(playerPlugin._methods.StartPlayback.notCalled);
+            this._mediaPlayer.beginPlaybackFrom(19);
+            assert(playerPlugin._methods.StartPlayback.calledWith(19));
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+        });
+    };
+    
+    this.SamsungStreamingMediaPlayerTests.prototype.testHlsGetPlayingRangeUpdateCalledBeforeJumpForward = function (queue) {
+        expectAsserts(8);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            assert(playerPlugin._methods.InitPlayer.notCalled);
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.LIVE_VIDEO, 'testURL', 'application/vnd.apple.mpegurl');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 100 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 0);
+            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + "-" + playerPlugin._range.end);
+            this._mediaPlayer._updatingTime = false;
+            
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+            assert(playerPlugin._methods.GetPlayingRange.calledOnce);
+            
+            playerPlugin._range = {
+                start: 24,
+                end: 124
+            };
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 22 * 1000);
+            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + "-" + playerPlugin._range.end);
+            
+            assert(playerPlugin._methods.JumpForward.notCalled);
+            this._mediaPlayer.playFrom(50);
+            assertEquals(this._mediaPlayer_range, playerPlugin._methods.GetPlayingRange.args[1][0]);
+            assert(playerPlugin._methods.GetPlayingRange.calledTwice);
+            assert(playerPlugin._methods.JumpForward.calledOnce);
+        });
+    };
+    
+    this.SamsungStreamingMediaPlayerTests.prototype.testHlsGetPlayingRangeUpdateCalledBeforeJumpBackward = function (queue) {
+        expectAsserts(8);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            assert(playerPlugin._methods.InitPlayer.notCalled);
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.LIVE_VIDEO, 'testURL', 'application/vnd.apple.mpegurl');
+            this._mediaPlayer.beginPlayback();
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 100, { start: 0, end: 100 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 90 * 1000);
+            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + "-" + playerPlugin._range.end);
+            this._mediaPlayer._updatingTime = false;
+            
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+            assert(playerPlugin._methods.GetPlayingRange.calledOnce);
+            
+            playerPlugin._range = {
+                start: 24,
+                end: 124
+            };
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 122 * 1000);
+            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + "-" + playerPlugin._range.end);
+            
+            assert(playerPlugin._methods.JumpBackward.notCalled);
+            this._mediaPlayer.playFrom(10);
+            assertEquals(this._mediaPlayer_range, playerPlugin._methods.GetPlayingRange.args[1][0]);
+            assert(playerPlugin._methods.GetPlayingRange.calledTwice);
+            assert(playerPlugin._methods.JumpBackward.calledOnce);
+        });
+    };
+    
+    this.SamsungStreamingMediaPlayerTests.prototype.testHlsGetPlayingRangeUpdateNotCalledWhileInRangeTolerance = function (queue) {
+        expectAsserts(6);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            assert(playerPlugin._methods.InitPlayer.notCalled);
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.LIVE_VIDEO, 'testURL', 'application/vnd.apple.mpegurl');
+            this._mediaPlayer.beginPlayback();
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 100, { start: 0, end: 100 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 100 * 1000);
+            
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+            assert(playerPlugin._methods.GetPlayingRange.calledOnce);
+            
+            this._mediaPlayer.playFrom(10);
+            assert(playerPlugin._methods.GetPlayingRange.calledOnce);
+            
+            this._mediaPlayer._updatingTime = false;
+            this._mediaPlayer.playFrom(20);
+            assert(playerPlugin._methods.GetPlayingRange.calledTwice);
+        });
+    };
+    
+    this.SamsungStreamingMediaPlayerTests.prototype.testHlsGetPlayingRangeUpdateOnCurrentTimeGreaterThanEndRangeTolerance = function (queue) {
+        expectAsserts(4);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.LIVE_VIDEO, 'testURL', 'application/vnd.apple.mpegurl');
+            this._mediaPlayer.beginPlayback();
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 100, { start: 0, end: 100 });
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 100 * 1000);
+            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + "-" + playerPlugin._range.end);
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            
+            assert(playerPlugin._methods.GetPlayingRange.calledOnce);
+            this._mediaPlayer._updatingTime = false;
+            
+            this._mediaPlayer._range = {
+                start: 24,
+                end: 124
+            };
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 133 * 1000);
+            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + "-" + playerPlugin._range.end);
+            
+            assertEquals(this._mediaPlayer_range, playerPlugin._methods.GetPlayingRange.args[1][0]);
+            assert(playerPlugin._methods.GetPlayingRange.calledTwice);
+            assert(playerPlugin._methods.JumpBackward.notCalled);
+        });
+    };
+    
+    this.SamsungStreamingMediaPlayerTests.prototype.testHlsGetPlayingRangeUpdateOnCurrentTimeLowerThanStartRangeTolerance = function (queue) {
+        expectAsserts(4);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.LIVE_VIDEO, 'testURL', 'application/vnd.apple.mpegurl');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 100 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME,  this._mediaPlayer.CLAMP_OFFSET_FROM_END_OF_RANGE * 1000);
+            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + "-" + playerPlugin._range.end);
+            
+            assert(playerPlugin._methods.GetPlayingRange.calledOnce);
+            this._mediaPlayer._updatingTime = false;
+            
+            this._mediaPlayer._range = {
+                start: 24,
+                end: 124
+            };
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 15 * 1000);
+            playerPlugin._methods.GetPlayingRange.returns(playerPlugin._range.start + "-" + playerPlugin._range.end);
+            
+            assertEquals(this._mediaPlayer_range, playerPlugin._methods.GetPlayingRange.args[1][0]);
+            assert(playerPlugin._methods.GetPlayingRange.calledTwice);
+            assert(playerPlugin._methods.JumpForward.notCalled);
+        });
+    };
+    /*HLS specific tests END*/
+    
+    this.SamsungStreamingMediaPlayerTests.prototype.testSetSourceInitPlayerFailsReturningZero = function(queue) {
+        var initPlayerReturnCode = 0;
+        doTestSetSourceInitPlayerFailsStartPlybackNotCalled(this, queue, initPlayerReturnCode);
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testSetSourceInitPlayerFailsReturningMinusOne = function(queue) {
+        var initPlayerReturnCode = -1;
+        doTestSetSourceInitPlayerFailsStartPlybackNotCalled(this, queue, initPlayerReturnCode);
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testSetSourceInitPlayerFailsReturningFalse = function(queue) {
+        var initPlayerReturnCode = false;
+        doTestSetSourceInitPlayerFailsStartPlybackNotCalled(this, queue, initPlayerReturnCode);
+    };
+
+    var doTestSetSourceInitPlayerFailsStartPlybackNotCalled = function(self, queue, initPlayerReturnCode) {
+        expectAsserts(5);
+        runMediaPlayerTest(self, queue, function(MediaPlayer) {
+            var eventHandler = self.sandbox.stub();
+            self._mediaPlayer.addEventCallback(null, eventHandler);
+            playerPlugin._methods.InitPlayer.returns(initPlayerReturnCode);
+            
+            try {
+                self._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+                self._mediaPlayer.beginPlayback();
+            } catch (e) {}            
+            
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            assert(playerPlugin._methods.StartPlayback.notCalled);
+            
+            assert(eventHandler.calledTwice);
+            assertEquals(MediaPlayer.EVENT.ERROR, eventHandler.args[1][0].type);
+            assertEquals("Failed to initialize video: testUrl", eventHandler.args[1][0].errorMessage);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testStartPlaybackCalledOnDeviceWhenBeginPlaybackFromCalledInStoppedState = function(queue) {
+        expectAsserts(9);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            assert(playerPlugin.Open.notCalled);
+            assert(playerPlugin._methods.InitPlayer.notCalled);
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
+            assert(playerPlugin.Open.calledWith("Player", "1.010", "Player"));
+            assert(playerPlugin.Open.calledOnce);
+            assert(playerPlugin._methods.InitPlayer.calledWith('testURL'));
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            
+            assert(playerPlugin._methods.StartPlayback.notCalled);
+            this._mediaPlayer.beginPlaybackFrom(0);
+            assert(playerPlugin._methods.StartPlayback.calledWith(0));
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayCalledOnDeviceWhenBeginPlaybackCalledInStoppedState = function(queue) {
+        expectAsserts(8);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            assert(playerPlugin.Open.notCalled);
+            assert(playerPlugin._methods.InitPlayer.notCalled);
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
+            assert(playerPlugin.Open.calledWith("Player", "1.010", "Player"));
+            assert(playerPlugin.Open.calledOnce);
+            assert(playerPlugin._methods.InitPlayer.calledWith('testURL'));
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            
+            assert(playerPlugin._methods.StartPlayback.notCalled);
+            this._mediaPlayer.beginPlayback();
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testBeginPlaybackFromSetsCurrentTimeAndCallsPlayOnMediaElementWhenInStoppedState = function(queue) {
+        expectAsserts(4);
+        runMediaPlayerTest(this, queue, function (MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
+            this._mediaPlayer.beginPlaybackFrom(10);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 100 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 19 * 1000);
+
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            assert(playerPlugin._methods.InitPlayer.calledWith('testURL'));
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+            assert(playerPlugin._methods.StartPlayback.calledWith(10));
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testResumePlayCalledWithTimePassedIntoBeginPlaybackFrom = function(queue) {
+        expectAsserts(9);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            assert(playerPlugin.Open.notCalled);
+            assert(playerPlugin._methods.InitPlayer.notCalled);
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
+            assert(playerPlugin.Open.calledWith("Player", "1.010", "Player"));
+            assert(playerPlugin.Open.calledOnce);
+            assert(playerPlugin._methods.InitPlayer.calledWith('testURL'));
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            
+            assert(playerPlugin._methods.StartPlayback.notCalled);
+            this._mediaPlayer.beginPlaybackFrom(19);
+            assert(playerPlugin._methods.StartPlayback.calledWith(19));
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromWhileBufferingDefersJumpUntilPlaying = function(queue) {
+        // Samsung advice to block seeking while buffering:
+        // http://www.samsungdforum.com/Guide/tec00118/index.html
+        expectAsserts(2);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 0);
+
+            deviceMockingHooks.startBuffering(this._mediaPlayer);
+
+            this._mediaPlayer.playFrom(50);
+            assert(playerPlugin._methods.JumpForward.notCalled);
+
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            deviceMockingHooks.makeOneSecondPass(this._mediaPlayer);
+            assert(playerPlugin._methods.JumpForward.calledOnce);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testJumpOnDeviceWhenPlayFromCalledInInitialBufferingState = function(queue) {
+        expectAsserts(10);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            assert(playerPlugin._methods.InitPlayer.calledWith('testUrl'));
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+            assert(playerPlugin._methods.StartPlayback.calledWith(0));
+            assert(playerPlugin._methods.JumpForward.notCalled);
+            this._mediaPlayer.playFrom(50);
+
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+            assert(playerPlugin._methods.JumpForward.notCalled);
+
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 0);
+
+            assert(playerPlugin._methods.JumpForward.calledOnce);
+            assert(playerPlugin._methods.JumpForward.calledWith(50));
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testNoSecondBufferingEventWhenPlayingFromABufferingState = function(queue) {
+        expectAsserts(3);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+
+            var eventHandler = this.sandbox.stub();
+            this._mediaPlayer.addEventCallback(null, eventHandler);
+
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            assertEquals(MediaPlayer.STATE.BUFFERING, this._mediaPlayer.getState());
+            var numEvents = eventHandler.callCount;
+            this._mediaPlayer.playFrom(10);
+            assertEquals(MediaPlayer.STATE.BUFFERING, this._mediaPlayer.getState());
+            assertEquals(numEvents, eventHandler.callCount);
+        });
+    };
+
+    // We ignore attempts to seek near the current time because in this situation, JumpForward() and JumpBackward()
+    // can return 1 (success) and then continue playing without a jump occurring. This leaves us in the BUFFERING state,
+    // because we wait for an OnBufferingStart/OnBufferingComplete pair. This is distinct from other tests below where
+    // JumpForward() and JumpBackward() return 0 (failure), in which case we are able to transition back to
+    // PLAYING in response.
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromCurrentTimeInPlayingStateBuffersThenPlays = function(queue) {
+        var initialTimeMs = 30000;
+        var targetTimeSecs = 30;
+        doTestPlayFromNearCurrentTimeInPlayingStateBuffersThenPlays(this, queue, initialTimeMs, targetTimeSecs);
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromNearAfterCurrentTimeInPlayingStateBuffersThenPlays = function(queue) {
+        var initialTimeMs = 30000;
+        var targetTimeSecs = 32.5;
+        doTestPlayFromNearCurrentTimeInPlayingStateBuffersThenPlays(this, queue, initialTimeMs, targetTimeSecs);
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromNearBeforeCurrentTimeInPlayingStateBuffersThenPlays = function(queue) {
+        var initialTimeMs = 30000;
+        var targetTimeSecs = 27.500;
+        doTestPlayFromNearCurrentTimeInPlayingStateBuffersThenPlays(this, queue, initialTimeMs, targetTimeSecs);
+    };
+
+    var doTestPlayFromNearCurrentTimeInPlayingStateBuffersThenPlays = function(self, queue, initialTimeMs, targetTimeSecs) {
+        expectAsserts(3);
+        runMediaPlayerTest(self, queue, function(MediaPlayer) {
+            self._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            self._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(self._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(self._mediaPlayer);
+
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, initialTimeMs);
+
+            var eventHandler = self.sandbox.stub();
+            self._mediaPlayer.addEventCallback(null, eventHandler);
+
+            self._mediaPlayer.playFrom(targetTimeSecs);
+            assert(eventHandler.calledTwice);
+            assertEquals(MediaPlayer.EVENT.BUFFERING, eventHandler.args[0][0].type);
+            assertEquals(MediaPlayer.EVENT.PLAYING, eventHandler.args[1][0].type);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromDifferentTimeWhenPlayingBuffersAndSeeks = function(queue) {
+        expectAsserts(10);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 0);
+
+            assertEquals(MediaPlayer.STATE.PLAYING, this._mediaPlayer.getState());
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+            assert(playerPlugin._methods.JumpForward.notCalled);
+
+            var eventHandler = this.sandbox.stub();
+            this._mediaPlayer.addEventCallback(null, eventHandler);
+
+            this._mediaPlayer.playFrom(50);
+            assert(eventHandler.calledOnce);
+            assertEquals(MediaPlayer.EVENT.BUFFERING, eventHandler.args[0][0].type);
+
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+            assert(playerPlugin._methods.JumpForward.calledOnce);
+            assert(playerPlugin._methods.JumpForward.calledWith(50));
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromEarlierTimeWhenPlayingBuffersAndSeeks = function(queue) {
+        expectAsserts(11);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(50);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 50, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 50000);
+
+            assertEquals(MediaPlayer.STATE.PLAYING, this._mediaPlayer.getState());
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+            assert(playerPlugin._methods.JumpBackward.notCalled);
+            assertEquals(50, this._mediaPlayer.getCurrentTime());
+
+            this._mediaPlayer.playFrom(20);
+
+            assertEquals(MediaPlayer.STATE.BUFFERING, this._mediaPlayer.getState());
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+            assert(playerPlugin._methods.JumpForward.notCalled);
+            assert(playerPlugin._methods.JumpBackward.calledOnce);
+            assert(playerPlugin._methods.JumpBackward.calledWith(30));
+        });
+    };
+    
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromEarlierTimeWhenPlayingThenPlayFromWhileBufferingSeeksAndPlays = function(queue) {
+        expectAsserts(14);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(50);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 50, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 50000);
+
+            assertEquals(MediaPlayer.STATE.PLAYING, this._mediaPlayer.getState());
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+            assert(playerPlugin._methods.JumpBackward.notCalled);
+            assertEquals(50, this._mediaPlayer.getCurrentTime());
+
+            assert(playerPlugin._methods.JumpBackward.notCalled);
+            this._mediaPlayer.playFrom(20);
+
+            assertEquals(MediaPlayer.STATE.BUFFERING, this._mediaPlayer.getState());
+            assert(playerPlugin._methods.JumpBackward.calledOnce);
+            assert(playerPlugin._methods.JumpBackward.calledWith(30));
+            
+            this._mediaPlayer.playFrom(10);
+            assert(playerPlugin._methods.JumpBackward.calledOnce);
+            assertEquals(MediaPlayer.STATE.BUFFERING, this._mediaPlayer.getState());
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 20000);
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            
+            assert(playerPlugin._methods.JumpBackward.calledTwice);
+            assertEquals(10, playerPlugin._methods.JumpBackward.args[1][0]);
+            
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 10000);
+            assertEquals(MediaPlayer.STATE.PLAYING, this._mediaPlayer.getState());
+        });
+    };
+
+    var doTestPlayFromNearCurrentTimeWhenPausedBuffersThenPlays = function(self, queue, initialTimeMs, targetTimeSecs) {
+        expectAsserts(5);
+        runMediaPlayerTest(self, queue, function(MediaPlayer) {
+            self._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            self._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(self._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(self._mediaPlayer);
+
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, initialTimeMs);
+            self._mediaPlayer.pause();
+
+            var eventHandler = self.sandbox.stub();
+            self._mediaPlayer.addEventCallback(null, eventHandler);
+
+            assert(playerPlugin._methods.Resume.notCalled);
+            self._mediaPlayer.playFrom(targetTimeSecs);
+            assert(playerPlugin._methods.Resume.calledOnce);
+            assert(eventHandler.calledTwice);
+            assertEquals(MediaPlayer.EVENT.BUFFERING, eventHandler.args[0][0].type);
+            assertEquals(MediaPlayer.EVENT.PLAYING, eventHandler.args[1][0].type);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromCurrentTimeWhenPausedBuffersThenPlays = function(queue) {
+        var initialTimeMs = 50000;
+        var targetTimeSecs = 50;
+        doTestPlayFromNearCurrentTimeWhenPausedBuffersThenPlays(this, queue, initialTimeMs, targetTimeSecs);
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromNearAfterCurrentTimeWhenPausedBuffersThenPlays = function(queue) {
+        var initialTimeMs = 50000;
+        var targetTimeSecs = 52.5;
+        doTestPlayFromNearCurrentTimeWhenPausedBuffersThenPlays(this, queue, initialTimeMs, targetTimeSecs);
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromNearBeforeCurrentTimeWhenPausedBuffersThenPlays = function(queue) {
+        var initialTimeMs = 50000;
+        var targetTimeSecs = 47.5;
+        doTestPlayFromNearCurrentTimeWhenPausedBuffersThenPlays(this, queue, initialTimeMs, targetTimeSecs);
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromDifferentTimeWhenPausedBuffersAndSeeks = function(queue) {
+        expectAsserts(10);
+        var self = this;
+        runMediaPlayerTest(self, queue, function(MediaPlayer) {
+            self._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            self._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(self._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(self._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 0);
+            self._mediaPlayer.pause();
+            assertEquals(MediaPlayer.STATE.PAUSED, self._mediaPlayer.getState());
+
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+            assert(playerPlugin._methods.JumpForward.notCalled);
+
+            var eventHandler = self.sandbox.stub();
+            self._mediaPlayer.addEventCallback(null, eventHandler);
+
+            self._mediaPlayer.playFrom(50);
+            assert(eventHandler.calledOnce);
+            assertEquals(MediaPlayer.EVENT.BUFFERING, eventHandler.args[0][0].type);
+
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+            assert(playerPlugin._methods.JumpForward.calledOnce);
+            assert(playerPlugin._methods.JumpForward.calledWith(50));
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromDifferentTimeWhenPausedResumesAfterJump = function(queue) {
+        expectAsserts(3);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 0);
+
+            this._mediaPlayer.pause();
+            assert(playerPlugin._methods.Resume.notCalled);
+
+            this._mediaPlayer.playFrom(50);
+            assert(playerPlugin._methods.Resume.calledOnce);
+            // Call Resume() after JumpForward() to avoid a single frame being played before the jump (D8000).
+            assert(playerPlugin._methods.Resume.calledAfter(playerPlugin._methods.JumpForward));
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromEarlierTimeWhenPausedBuffersAndSeeks = function(queue) {
+        expectAsserts(11);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(50);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 50, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 50000);
+            this._mediaPlayer.pause();
+
+            assertEquals(MediaPlayer.STATE.PAUSED, this._mediaPlayer.getState());
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+            assert(playerPlugin._methods.JumpBackward.notCalled);
+            assertEquals(50, this._mediaPlayer.getCurrentTime());
+
+            this._mediaPlayer.playFrom(20);
+
+            assertEquals(MediaPlayer.STATE.BUFFERING, this._mediaPlayer.getState());
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+            assert(playerPlugin._methods.JumpForward.notCalled);
+            assert(playerPlugin._methods.JumpBackward.calledOnce);
+            assert(playerPlugin._methods.JumpBackward.calledWith(30));
+        });
+    };
+
+
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testResumeWhenPausedCallsResume = function(queue) {
+        expectAsserts(3);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            this._mediaPlayer.pause();
+            assertEquals(MediaPlayer.STATE.PAUSED, this._mediaPlayer.getState());
+
+            assert(playerPlugin._methods.Resume.notCalled);
+            
+            this._mediaPlayer.resume();
+
+            assert(playerPlugin._methods.Resume.calledOnce);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPauseCallsPauseWhenPlaying = function(queue) {
+        expectAsserts(3);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+
+            assert(playerPlugin._methods.Pause.notCalled);
+            assertEquals(MediaPlayer.STATE.PLAYING, this._mediaPlayer.getState());
+
+            this._mediaPlayer.pause();
+
+            assert(playerPlugin._methods.Pause.calledOnce);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testStopCallsStopWhenPlaying = function(queue) {
+        expectAsserts(3);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+
+            assert(playerPlugin._methods.Stop.notCalled);
+            assertEquals(MediaPlayer.STATE.PLAYING, this._mediaPlayer.getState());
+
+            this._mediaPlayer.stop();
+
+            assert(playerPlugin._methods.Stop.calledOnce);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testMediaStoppedOnTransitionToErrorState = function(queue) {
+        expectAsserts(2);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+
+            assert(playerPlugin._methods.Stop.notCalled);
+
+            try {
+                this._mediaPlayer.beginPlayback();
+            } catch (e) {}
+
+            assert(playerPlugin._methods.Stop.calledOnce);
+        });
+    };
+
+    function assert_x3_matchErrorEvent(eventHandler, expectedErrorType, expectedErrorMessage) {
+        var actualEventArgs = eventHandler.args[0][0];
+
+        assert(eventHandler.calledOnce);
+        assertEquals(expectedErrorType, actualEventArgs.type);
+        assertEquals(expectedErrorMessage, actualEventArgs.errorMessage);
+    }
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testOnRenderErrorCausesErrorEvent = function(queue) {
+        expectAsserts(4);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
+
+            var eventHandler = this.sandbox.stub();
+            this._mediaPlayer.addEventCallback(null, eventHandler);
+            
+            playerPlugin.OnEvent(listenerEventCodes.RENDER_ERROR);
+
+            var expectedError = 'Media element emitted OnRenderError';
+            assert_x3_matchErrorEvent(eventHandler, MediaPlayer.EVENT.ERROR, expectedError);
+
+            assert(this._errorLog.withArgs(expectedError).calledOnce);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testOnConnectionFailedCausesErrorEvent = function(queue) {
+        expectAsserts(4);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
+
+            var eventHandler = this.sandbox.stub();
+            this._mediaPlayer.addEventCallback(null, eventHandler);
+
+            playerPlugin.OnEvent(listenerEventCodes.CONNECTION_FAILED);
+
+            var expectedError = 'Media element emitted OnConnectionFailed';
+            assert_x3_matchErrorEvent(eventHandler, MediaPlayer.EVENT.ERROR, expectedError);
+
+            assert(this._errorLog.withArgs(expectedError).calledOnce);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testOnNetworkDisconnectedCausesErrorEvent = function(queue) {
+        expectAsserts(4);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
+
+            var eventHandler = this.sandbox.stub();
+            this._mediaPlayer.addEventCallback(null, eventHandler);
+
+            playerPlugin.OnEvent(listenerEventCodes.NETWORK_DISCONNECTED);
+
+            var expectedError = 'Media element emitted OnNetworkDisconnected';
+            assert_x3_matchErrorEvent(eventHandler, MediaPlayer.EVENT.ERROR, expectedError);
+
+            assert(this._errorLog.withArgs(expectedError).calledOnce);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testOnStreamNotFoundCausesErrorEvent = function(queue) {
+        expectAsserts(4);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
+
+            var eventHandler = this.sandbox.stub();
+            this._mediaPlayer.addEventCallback(null, eventHandler);
+
+            playerPlugin.OnEvent(listenerEventCodes.STREAM_NOT_FOUND);
+
+            var expectedError = 'Media element emitted OnStreamNotFound';
+            assert_x3_matchErrorEvent(eventHandler, MediaPlayer.EVENT.ERROR, expectedError);
+
+            assert(this._errorLog.withArgs(expectedError).calledOnce);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testOnAuthenticationFailedCausesErrorEvent = function(queue) {
+        expectAsserts(4);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
+
+            var eventHandler = this.sandbox.stub();
+            this._mediaPlayer.addEventCallback(null, eventHandler);
+
+            playerPlugin.OnEvent(listenerEventCodes.AUTHENTICATION_FAILED);
+
+            var expectedError = 'Media element emitted OnAuthenticationFailed';
+            assert_x3_matchErrorEvent(eventHandler, MediaPlayer.EVENT.ERROR, expectedError);
+
+            assert(this._errorLog.withArgs(expectedError).calledOnce);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromTimeGreaterThanDurationWhilstPlayingClampsToJustBeforeEnd = function(queue) {
+        expectAsserts(3);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            playerPlugin._range = { start: 0, end: 60 };
+            playerPlugin._methods.GetDuration.returns(playerPlugin._range.end * 1000);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 0);
+
+            assert(playerPlugin._methods.JumpForward.notCalled);
+
+            this._mediaPlayer.playFrom(100);
+
+            assert(playerPlugin._methods.JumpForward.calledOnce);
+            assert(playerPlugin._methods.JumpForward.calledWith(58.9));
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromTimeGreaterThanDurationWhilstMidStreamBufferingClampsToJustBeforeEnd = function(queue) {
+        expectAsserts(3);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            playerPlugin._range = { start: 0, end: 60 };
+            playerPlugin._methods.GetDuration.returns(playerPlugin._range.end * 1000);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 0);
+            deviceMockingHooks.startBuffering(this._mediaPlayer);
+
+            assert(playerPlugin._methods.JumpForward.notCalled);
+
+            this._mediaPlayer.playFrom(100);
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 0);
+
+            assert(playerPlugin._methods.JumpForward.calledOnce);
+            assertEquals(58.9, playerPlugin._methods.JumpForward.args[0][0]);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromTimeGreaterThanDurationWhilstInitialBufferingClampsToJustBeforeEnd = function(queue) {
+        expectAsserts(4);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+
+            assert(playerPlugin._methods.JumpForward.notCalled);
+
+            this._mediaPlayer.playFrom(100);
+
+            assert(playerPlugin._methods.JumpForward.notCalled);
+
+            playerPlugin._range = { start: 0, end: 60 };
+            playerPlugin._methods.GetDuration.returns(playerPlugin._range.end * 1000);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 0);
+
+            assert(playerPlugin._methods.JumpForward.calledOnce);
+            assertEquals(58.9, playerPlugin._methods.JumpForward.args[0][0]);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromTimeGreaterThanDurationWhilstPausedClampsToJustBeforeEnd = function(queue) {
+        expectAsserts(3);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            playerPlugin._range = { start: 0, end: 60 };
+            playerPlugin._methods.GetDuration.returns(playerPlugin._range.end * 1000);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 0);
+            this._mediaPlayer.pause();
+
+            assert(playerPlugin._methods.JumpForward.notCalled);
+
+            this._mediaPlayer.playFrom(100);
+            assert(playerPlugin._methods.JumpForward.calledOnce);
+            assert(playerPlugin._methods.JumpForward.calledWith(58.9));
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromTimeGreaterThanDurationWhilstCompleteClampsToJustBeforeEnd = function(queue) {
+        expectAsserts(3);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            playerPlugin._range = { start: 0, end: 60 };
+            playerPlugin._methods.GetDuration.returns(playerPlugin._range.end * 1000);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            
+            deviceMockingHooks.reachEndOfMedia(this._mediaPlayer);
+            this._mediaPlayer.playFrom(100);
+
+            assert(playerPlugin._methods.Stop.called);
+            assert(playerPlugin._methods.StartPlayback.calledTwice);
+            debugger;assertEquals(58.9, playerPlugin._methods.StartPlayback.args[1][0]);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromAfterMediaCompletedCallsStopBeforeResumePlay = function(queue) {
+        expectAsserts(5);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            deviceMockingHooks.reachEndOfMedia(this._mediaPlayer);
+
+            assert(playerPlugin._methods.Stop.notCalled);
+            playerPlugin._methods.InitPlayer.reset();
+            playerPlugin._methods.StartPlayback.reset();
+
+            this._mediaPlayer.playFrom(0);
+
+            assert(playerPlugin._methods.Stop.calledOnce);
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            assert(playerPlugin._methods.StartPlayback.calledOnce);
+            assert(playerPlugin._methods.Stop.calledBefore(playerPlugin._methods.InitPlayer));
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromWhileAtNonZeroTimeGCausesRelativeJump = function(queue) {
+        expectAsserts(4);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 10000);
+
+            assertEquals(10, this._mediaPlayer.getCurrentTime());
+            assert(playerPlugin._methods.JumpForward.notCalled);
+
+            this._mediaPlayer.playFrom(30);
+
+            assert(playerPlugin._methods.JumpForward.calledOnce);
+            assert(playerPlugin._methods.JumpForward.calledWith(20));
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testStatusMessageIncludesUpdatedTime = function(queue) {
+        expectAsserts(4);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+
+            var callback = this.sandbox.stub();
+            this._mediaPlayer.addEventCallback(null, callback);
+
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 10000);
+            
+            assert(callback.calledOnce);
+            assertEquals(10, callback.args[0][0].currentTime);
+
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 20000);
+
+            assert(callback.calledTwice);
+            assertEquals(20, callback.args[1][0].currentTime);
+
+
+        });
+    };
+
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPausingBeforeMetaDataLoadsResultsInPausedStateWhenDeviceIsAbleToPauseAfterBuffering = function(queue) {
+        expectAsserts(2);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            this._mediaPlayer.pause();
+
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+
+            assertEquals(MediaPlayer.STATE.PAUSED, this._mediaPlayer.getState());
+            assert(playerPlugin._methods.Pause.calledOnce);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPausingBeforeMetaDataLoadsRemainsInBufferingStateWhenDeviceIsUnableToPauseAfterBuffering = function(queue) {
+        expectAsserts(1);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            this._mediaPlayer.pause();
+
+            playerPlugin._methods.Pause.returns(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+
+            assertEquals(MediaPlayer.STATE.BUFFERING, this._mediaPlayer.getState());
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPausingBeforeMetaDataLoadsResultsInSecondAttemptToPauseAfterBufferingWhenInitialPauseFailsReturningZero = function(queue) {
+        var pauseReturnCode = 0;
+        doTestPausingBeforeMetaDataLoadsResultsInSecondAttemptToPauseAfterBufferingWhenInitialPauseFails(this, queue, pauseReturnCode);
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPausingBeforeMetaDataLoadsResultsInSecondAttemptToPauseAfterBufferingWhenInitialPauseFailsReturningMinusOne = function(queue) {
+        var pauseReturnCode = -1;
+        doTestPausingBeforeMetaDataLoadsResultsInSecondAttemptToPauseAfterBufferingWhenInitialPauseFails(this, queue, pauseReturnCode);
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPausingBeforeMetaDataLoadsResultsInSecondAttemptToPauseAfterBufferingWhenInitialPauseFailsReturningFalse = function(queue) {
+        var pauseReturnCode = false;
+        doTestPausingBeforeMetaDataLoadsResultsInSecondAttemptToPauseAfterBufferingWhenInitialPauseFails(this, queue, pauseReturnCode);
+    };
+
+    var doTestPausingBeforeMetaDataLoadsResultsInSecondAttemptToPauseAfterBufferingWhenInitialPauseFails = function(self, queue, pauseReturnCode) {
+        expectAsserts(2);
+        runMediaPlayerTest(self, queue, function(MediaPlayer) {
+            self._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            self._mediaPlayer.beginPlaybackFrom(0);
+            self._mediaPlayer.pause();
+
+            playerPlugin._methods.Pause.returns(pauseReturnCode);
+            deviceMockingHooks.sendMetadata(self._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(self._mediaPlayer);
+
+            assert(playerPlugin._methods.Pause.calledOnce);
+
+            deviceMockingHooks.makeOneSecondPass(self._mediaPlayer);
+            assert(playerPlugin._methods.Pause.calledTwice);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPausingBeforeMetaDataLoadsThenResumingWhileAttemptingToPauseResultsInPlayingState = function(queue) {
+        expectAsserts(1);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            this._mediaPlayer.pause();
+
+            playerPlugin._methods.Pause.returns(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+
+            this._mediaPlayer.resume();
+            playerPlugin._methods.Pause.returns(1);
+            deviceMockingHooks.makeOneSecondPass(this._mediaPlayer);
+
+            assertEquals(MediaPlayer.STATE.PLAYING, this._mediaPlayer.getState());
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPausingBeforeMetaDataLoadsResultsInPausedStateWhenPausedAfterMultipleAttempts = function(queue) {
+        expectAsserts(4);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            this._mediaPlayer.pause();
+
+            playerPlugin._methods.Pause.returns(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+
+            assert(playerPlugin._methods.Pause.calledOnce);
+
+            deviceMockingHooks.makeOneSecondPass(this._mediaPlayer);
+            assert(playerPlugin._methods.Pause.calledTwice);
+
+            playerPlugin._methods.Pause.returns(1);
+
+            deviceMockingHooks.makeOneSecondPass(this._mediaPlayer);
+            assert(playerPlugin._methods.Pause.calledThrice);
+            assertEquals(MediaPlayer.STATE.PAUSED, this._mediaPlayer.getState());
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testStatusEventsOnlyEmittedInPlayingState = function(queue) {
+        expectAsserts(1);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            this._mediaPlayer.pause();
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+
+            var callback = this.sandbox.stub();
+            this._mediaPlayer.addEventCallback(null, callback);
+
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 10000);
+
+            assert(callback.notCalled);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromWhilePlayingBeforeFirstStatusEventDefersJumpAndJumpsByCorrectAmount = function(queue) {
+        expectAsserts(4);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(30);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 30, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+
+            assert(playerPlugin._methods.JumpForward.notCalled);
+            this._mediaPlayer.playFrom(50);
+
+            assert(playerPlugin._methods.JumpForward.notCalled);
+
+            // Device may not start playback from exactly the position requested, e.g. it may go to a keyframe
+            var positionCloseToRequestedPosition = 32000;
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, positionCloseToRequestedPosition);
+
+            assert(playerPlugin._methods.JumpForward.calledOnce);
+            assertEquals(18, playerPlugin._methods.JumpForward.args[0][0]);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromWhilePausedBeforeFirstStatusEventDefersJumpAndJumpsByCorrectAmount = function(queue) {
+        expectAsserts(4);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(30);
+            this._mediaPlayer.pause();
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 30, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+
+            assert(playerPlugin._methods.JumpForward.notCalled);
+
+            this._mediaPlayer.playFrom(50);
+
+            assert(playerPlugin._methods.JumpForward.notCalled);
+
+            // Device may not start playback from exactly the position requested, e.g. it may go to a keyframe
+            var positionCloseToRequestedPosition = 32000;
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, positionCloseToRequestedPosition);
+
+            assert(playerPlugin._methods.JumpForward.calledOnce);
+            assertEquals(18, playerPlugin._methods.JumpForward.args[0][0]);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testMediaPlayerIsStoppedOnAppHide = function(queue) {
+        expectAsserts(3);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+
+            var addStub = this.sandbox.stub(window, 'addEventListener');
+
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlayback();
+
+            var filtered = addStub.withArgs('hide', sinon.match.func, false);
+            assert(filtered.calledOnce);
+            var addedCallback = filtered.args[0][1];
+
+            assert(playerPlugin._methods.Stop.notCalled);
+
+            addedCallback(new CustomEvent('hide') );
+
+            assert(playerPlugin._methods.Stop.calledOnce);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testMediaPlayerIsStoppedOnAppUnload = function(queue) {
+        expectAsserts(3);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+
+            var addStub = this.sandbox.stub(window, 'addEventListener');
+
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlayback();
+
+            var filtered = addStub.withArgs('unload', sinon.match.func, false);
+            assert(filtered.calledOnce);
+            var addedCallback = filtered.args[0][1];
+
+            assert(playerPlugin._methods.Stop.notCalled);
+
+            addedCallback(new CustomEvent('unload'));
+
+            assert(playerPlugin._methods.Stop.calledOnce);
+        });
+    };
+    
+    this.SamsungStreamingMediaPlayerTests.prototype.testMediaPlayerIgnorePeriodicRenderingCompleteEventInCompleteState = function (queue) {
+        expectAsserts(4);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlayback();
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 0);
+            
+            var eventHandler = this.sandbox.stub();
+            this._mediaPlayer.addEventCallback(null, eventHandler);
+            
+            assert(eventHandler.notCalled);
+            deviceMockingHooks.reachEndOfMedia(this._mediaPlayer);
+            assertEquals(MediaPlayer.EVENT.COMPLETE, eventHandler.args[1][0].type);
+            assert(eventHandler.calledTwice);
+            
+            //if Stop() is not called after RENDERING_COMPLETE then player sends periodically BUFFERING_COMPLETE and RENDERING_COMPLETE
+            //ignore BUFFERING_COMPLETE and RENDERING_COMPLETE if player is already in COMPLETE state
+            playerPlugin.OnEvent(listenerEventCodes.BUFFERING_COMPLETE);
+            playerPlugin.OnEvent(listenerEventCodes.RENDERING_COMPLETE);
+            
+            assert(eventHandler.calledTwice);
+        });
+    };
+    
+    this.SamsungStreamingMediaPlayerTests.prototype.testPluginCloseCalledOnReset = function(queue) {
+        expectAsserts(6);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            assert(playerPlugin.Open.notCalled);            
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            assert(playerPlugin.Open.calledOnce);
+            
+            assert(playerPlugin.Close.notCalled); 
+            this._mediaPlayer.reset();
+            assert(playerPlugin.Close.calledOnce);
+                        
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            assert(playerPlugin.Close.calledOnce);
+            assert(playerPlugin.Open.calledTwice);            
+        });
+    };
+    
+    this.SamsungStreamingMediaPlayerTests.prototype.testPluginCloseNotCalledAfterStopCalledThenStartPlayback = function(queue) {
+        expectAsserts(7);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            assert(playerPlugin.Open.notCalled);            
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlayback();
+            assert(playerPlugin.Open.calledOnce);
+             
+            this._mediaPlayer.stop();
+            assert(playerPlugin.Close.notCalled);
+                        
+            this._mediaPlayer.beginPlayback();
+            assert(playerPlugin.Close.notCalled);
+            assert(playerPlugin.Open.calledOnce); 
+            assert(playerPlugin._methods.InitPlayer.calledOnce);
+            assert(playerPlugin._methods.StartPlayback.calledTwice);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testWindowHideEventListenerIsTornDownOnReset = function(queue) {
+        expectAsserts(4);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+
+            var addStub = this.sandbox.stub(window, 'addEventListener');
+            var removeStub = this.sandbox.stub(window, 'removeEventListener');
+
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+
+            var filteredAdd = addStub.withArgs('hide', sinon.match.func, false);
+            assert(filteredAdd.calledOnce);
+            var addedCallback = filteredAdd.args[0][1];
+
+            assert(removeStub.notCalled);
+
+            this._mediaPlayer.reset();
+
+            var filteredRemove = removeStub.withArgs('hide', sinon.match.func, false);
+            assert(filteredRemove.calledOnce);
+            var removedCallback = filteredRemove.args[0][1];
+            assertSame(addedCallback, removedCallback);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testWindowUnloadEventListenerIsTornDownOnReset = function(queue) {
+        expectAsserts(4);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+
+            var addStub = this.sandbox.stub(window, 'addEventListener');
+            var removeStub = this.sandbox.stub(window, 'removeEventListener');
+
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+
+            var filteredAdd = addStub.withArgs('unload', sinon.match.func, false);
+            assert(filteredAdd.calledOnce);
+            var addedCallback = filteredAdd.args[0][1];
+
+            assert(removeStub.notCalled);
+
+            this._mediaPlayer.reset();
+
+            var filteredRemove = removeStub.withArgs('unload', sinon.match.func, false);
+            assert(filteredRemove.calledOnce);
+            var removedCallback = filteredRemove.args[0][1];
+            assertSame(addedCallback, removedCallback);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testCurrentTimeIsUpdatedByOnCurrentPlayTimeEvents = function(queue) {
+        expectAsserts(4);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+
+            assertEquals(MediaPlayer.STATE.PLAYING, this._mediaPlayer.getState());
+
+            assertEquals(0, this._mediaPlayer.getCurrentTime());
+
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 10000);
+
+            assertEquals(10, this._mediaPlayer.getCurrentTime());
+
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 20000);
+
+            assertEquals(20, this._mediaPlayer.getCurrentTime());
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testFailedJumpReturningZeroWhilePlayingReturnsToPlayingState = function(queue) {
+        var jumpReturnCode = 0;
+        doTestFailedJumpWhilePlayingReturnsToPlayingState(this, queue, jumpReturnCode);
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testFailedJumpReturningMinusOneWhilePlayingReturnsToPlayingState = function(queue) {
+        var jumpReturnCode = -1;
+        doTestFailedJumpWhilePlayingReturnsToPlayingState(this, queue, jumpReturnCode);
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testFailedJumpReturningFalseWhilePlayingReturnsToPlayingState = function(queue) {
+        var jumpReturnCode = false;
+        doTestFailedJumpWhilePlayingReturnsToPlayingState(this, queue, jumpReturnCode);
+    };
+
+    var doTestFailedJumpWhilePlayingReturnsToPlayingState = function(self, queue, jumpReturnCode) {
+        expectAsserts(5);
+        runMediaPlayerTest(self, queue, function(MediaPlayer) {
+            self._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            self._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(self._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(self._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 0);
+
+            assertEquals(MediaPlayer.STATE.PLAYING, self._mediaPlayer.getState());
+
+            var eventHandler = self.sandbox.stub();
+            self._mediaPlayer.addEventCallback(null, eventHandler);
+            playerPlugin._methods.JumpForward.returns(jumpReturnCode);
+
+            self._mediaPlayer.playFrom(30);
+
+            assert(eventHandler.calledTwice);
+            assertEquals(MediaPlayer.EVENT.BUFFERING, eventHandler.firstCall.args[0].type);
+            assertEquals(MediaPlayer.EVENT.PLAYING, eventHandler.lastCall.args[0].type);
+            assertEquals(MediaPlayer.STATE.PLAYING, self._mediaPlayer.getState());
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testFailedJumpReturningZeroWhilePausedGoesToPlayingState = function(queue) {
+        var jumpReturnCode = 0;
+        doTestFailedJumpWhilePausedReturnsToPlayingState(this, queue, jumpReturnCode);
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testFailedJumpReturningMinusOneWhilePausedGoesToPlayingState = function(queue) {
+        var jumpReturnCode = -1;
+        doTestFailedJumpWhilePausedReturnsToPlayingState(this, queue, jumpReturnCode);
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testFailedJumpReturningFalseWhilePausedGoesToPlayingState = function(queue) {
+        var jumpReturnCode = false;
+        doTestFailedJumpWhilePausedReturnsToPlayingState(this, queue, jumpReturnCode);
+    };
+
+    var doTestFailedJumpWhilePausedReturnsToPlayingState = function(self, queue, jumpReturnCode) {
+        expectAsserts(5);
+        runMediaPlayerTest(self, queue, function(MediaPlayer) {
+            self._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            self._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(self._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(self._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 0);
+
+            self._mediaPlayer.pause();
+            assertEquals(MediaPlayer.STATE.PAUSED, self._mediaPlayer.getState());
+
+            var eventHandler = self.sandbox.stub();
+            self._mediaPlayer.addEventCallback(null, eventHandler);
+            playerPlugin._methods.JumpForward.returns(jumpReturnCode);
+
+            self._mediaPlayer.playFrom(30);
+
+            assert(eventHandler.calledTwice);
+            assertEquals(MediaPlayer.EVENT.BUFFERING, eventHandler.firstCall.args[0].type);
+            assertEquals(MediaPlayer.EVENT.PLAYING, eventHandler.lastCall.args[0].type);
+            assertEquals(MediaPlayer.STATE.PLAYING, self._mediaPlayer.getState());
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testFailedDeferredJumpRemainsInBufferingState = function(queue) {
+        expectAsserts(5);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            this._mediaPlayer.playFrom(30);
+
+            var eventHandler = this.sandbox.stub();
+            this._mediaPlayer.addEventCallback(null, eventHandler);
+            playerPlugin._methods.JumpForward.returns(0);
+
+            assert(eventHandler.notCalled);
+            assert(playerPlugin._methods.JumpForward.notCalled);
+            assertEquals(MediaPlayer.STATE.BUFFERING, this._mediaPlayer.getState());
+
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 0);
+
+            assert(playerPlugin._methods.JumpForward.calledOnce);
+            assertEquals(MediaPlayer.STATE.BUFFERING, this._mediaPlayer.getState());
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testFailedDeferredJumpResultsInRepeatedAttemptsToJumpUntilSuccess = function(queue) {
+        expectAsserts(8);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            this._mediaPlayer.playFrom(30);
+
+            var eventHandler = this.sandbox.stub();
+            this._mediaPlayer.addEventCallback(null, eventHandler);
+            playerPlugin._methods.JumpForward.returns(0);
+
+            assert(eventHandler.notCalled);
+            assert(playerPlugin._methods.JumpForward.notCalled);
+            assertEquals(MediaPlayer.STATE.BUFFERING, this._mediaPlayer.getState());
+
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 0);
+
+            assert(playerPlugin._methods.JumpForward.calledOnce);
+
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 1);
+            assert(playerPlugin._methods.JumpForward.calledTwice);
+
+            playerPlugin._methods.JumpForward.returns(1);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 2);
+            assert(playerPlugin._methods.JumpForward.calledThrice);
+
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 3);
+            assert(playerPlugin._methods.JumpForward.calledThrice);
+
+            // No additional events - we remain in BUFFERING
+            assert(eventHandler.notCalled);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testDeferredJumpsDoNotReenterBufferingState = function(queue) {
+        expectAsserts(3);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            this._mediaPlayer.playFrom(30);
+
+            var eventHandler = this.sandbox.stub();
+            this._mediaPlayer.addEventCallback(null, eventHandler);
+            playerPlugin._methods.JumpForward.returns(0);
+
+            assert(eventHandler.notCalled);
+            assertEquals(MediaPlayer.STATE.BUFFERING, this._mediaPlayer.getState());
+
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 0);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 1);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 2);
+
+            assert(eventHandler.withArgs(sinon.match({ type: MediaPlayer.EVENT.BUFFERING })).notCalled);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testDeferredSeekIsCancelledWhenTargetIsCurrentTime = function(queue) {
+        var targetTime = 30;
+        doTestDeferredSeekIsCancelledWhenTargetIsNearCurrentTime(this, queue, targetTime);
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testDeferredSeekIsCancelledWhenTargetIsNearAfterCurrentTime = function(queue) {
+        var targetTime = 32.5;
+        doTestDeferredSeekIsCancelledWhenTargetIsNearCurrentTime(this, queue, targetTime);
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testDeferredSeekIsCancelledWhenTargetIsNearBeforeCurrentTime = function(queue) {
+        var targetTime = 27.5;
+        doTestDeferredSeekIsCancelledWhenTargetIsNearCurrentTime(this, queue, targetTime);
+    };
+
+    var doTestDeferredSeekIsCancelledWhenTargetIsNearCurrentTime = function(self, queue, targetTime) {
+        expectAsserts(4);
+        runMediaPlayerTest(self, queue, function(MediaPlayer) {
+            self._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            self._mediaPlayer.beginPlaybackFrom(30);
+
+            assertEquals(MediaPlayer.STATE.BUFFERING, self._mediaPlayer.getState());
+
+            self._mediaPlayer.playFrom(50);
+            self._mediaPlayer.playFrom(targetTime);
+
+            var eventHandler = self.sandbox.stub();
+            self._mediaPlayer.addEventCallback(null, eventHandler);
+
+            deviceMockingHooks.sendMetadata(self._mediaPlayer, 30, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(self._mediaPlayer);
+
+            var deviceSeeksToKeyFrameAtPosition = 30000;
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, deviceSeeksToKeyFrameAtPosition);
+
+            assert(playerPlugin._methods.JumpForward.notCalled);
+            assert(playerPlugin._methods.JumpBackward.notCalled);
+            assertEquals(MediaPlayer.STATE.PLAYING, self._mediaPlayer.getState());
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testPlayFromAndPauseBeforeMetaDataLoadsResultsInSeekFirstThenPauseWithCurrentTime = function(queue) {
+        expectAsserts(5);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            this._mediaPlayer.playFrom(30);
+            this._mediaPlayer.pause();
+
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 0);
+
+            // Remains in buffering state because we need to seek
+            assertEquals(MediaPlayer.STATE.BUFFERING, this._mediaPlayer.getState());
+            assert(playerPlugin._methods.JumpForward.calledOnce);
+
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+
+            assert(playerPlugin._methods.Pause.calledOnce);
+            assertEquals(MediaPlayer.STATE.PAUSED, this._mediaPlayer.getState());
+            assertEquals(30, this._mediaPlayer.getCurrentTime());
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testDeferredSeekDoesNotPersistAfterReset = function(queue) {
+        expectAsserts(1);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 30, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+
+            this._mediaPlayer.playFrom(50);
+
+            this._mediaPlayer.stop();
+            this._mediaPlayer.reset();
+
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 30, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 0);
+
+            assert(playerPlugin._methods.JumpForward.notCalled);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testDeferredPauseDoesNotPersistAfterReset = function(queue) {
+        expectAsserts(2);
+        playerPlugin._methods.Pause.returns(0);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            this._mediaPlayer.pause();
+            
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 30, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+
+            assert(playerPlugin._methods.Pause.calledOnce);
+
+            this._mediaPlayer.stop();
+            this._mediaPlayer.reset();
+
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testUrl', 'testMimeType');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 30, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            playerPlugin.OnEvent(listenerEventCodes.CURRENT_PLAYBACK_TIME, 0);
+
+            assert(playerPlugin._methods.Pause.calledOnce);
+        });
+        playerPlugin._methods.Pause.returns(1);
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testMediaUrlGetsSpecialHlsFragmentAppended = function(queue) {
+        expectAsserts(1);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'test/url', 'application/vnd.apple.mpegurl');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            assert(playerPlugin._methods.InitPlayer.calledWith('test/url|COMPONENT=HLS'));
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testMediaUrlGetsSpecialHlsFragmentAppendedWithXMpegUrl = function(queue) {
+        expectAsserts(1);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'test/url', 'application/x-mpegURL');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            assert(playerPlugin._methods.InitPlayer.calledWith('test/url|COMPONENT=HLS'));
+        });
+    };
+    
+    this.SamsungStreamingMediaPlayerTests.prototype.testMediaUrlGetsSpecialHlsLiveFragmentAppended = function(queue) {
+        expectAsserts(1);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.LIVE_VIDEO, 'test/url', 'application/vnd.apple.mpegurl');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            assert(playerPlugin._methods.InitPlayer.calledWith('test/url|HLSSLIDING|COMPONENT=HLS'));
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testMediaUrlGetsSpecialHlsLiveFragmentAppendedWithXMpegUrl = function(queue) {
+        expectAsserts(1);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.LIVE_VIDEO, 'test/url', 'application/x-mpegURL');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            assert(playerPlugin._methods.InitPlayer.calledWith('test/url|HLSSLIDING|COMPONENT=HLS'));
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testGetSourceDoesNotHaveSpecialHlsFragmentAppended = function(queue) {
+        expectAsserts(1);
+        runMediaPlayerTest(this, queue, function(MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'test/url', 'video/mp4');
+            this._mediaPlayer.beginPlaybackFrom(0);
+            deviceMockingHooks.sendMetadata(this._mediaPlayer, 0, { start: 0, end: 60 });
+            deviceMockingHooks.finishBuffering(this._mediaPlayer);
+            assert(this._mediaPlayer.getSource().indexOf('|COMPONENT=HLS') === -1);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testCallingStopFromStoppedStateDoesNotCallDeviceStop = function(queue) {
+        expectAsserts(1);
+        runMediaPlayerTest(this, queue, function (MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'http://testurl/', 'video/mp4');
+            playerPlugin._methods.Stop.reset();
+
+            this._mediaPlayer.stop();
+            assert(playerPlugin._methods.Stop.notCalled);
+        });
+    };
+
+    this.SamsungStreamingMediaPlayerTests.prototype.testGetPlayerElement = function(queue) {
+        expectAsserts(1);
+        runMediaPlayerTest(this, queue, function (MediaPlayer) {
+            this._mediaPlayer.setSource(MediaPlayer.TYPE.VIDEO, 'testURL', 'video/mp4');
+            assertEquals(playerPlugin, this._mediaPlayer.getPlayerElement());
+        });
+    };
+
+    // **** WARNING **** WARNING **** WARNING: These TODOs are NOT complete/exhaustive
+    // TODO: Investigate if we should keep a reference to the original player plugin and restore on tear-down in the same way media/samsung_streaming modifier
+    // -- This appears to only be the tvmwPlugin - if we don't need it then we shouldn't modify it.
+    // -- UPDATE: I haven't seen any ill effects on the 2013 FoxP from not using tvmwPlugin - needs further
+    //    investigation on other devices.
+
+    //---------------------
+    // Common tests
+    //---------------------
+
+    // Mixin the common tests shared by all MediaPlayer implementations (last, so it can detect conflicts)
+    window.commonTests.mediaPlayer.all.mixinTests(this.SamsungStreamingMediaPlayerTests, 'antie/devices/mediaplayer/samsung_streaming', config, deviceMockingHooks);
+
+})();

--- a/static/script/devices/mediaplayer/samsung_streaming.js
+++ b/static/script/devices/mediaplayer/samsung_streaming.js
@@ -243,7 +243,7 @@ require.def(
              */
             beginPlaybackFrom: function(seconds) {
                 this._postBufferingState = MediaPlayer.STATE.PLAYING;
-                var seekingTo = this._range ? this._getClampedTimeForPlayFrom(seconds) : seconds;
+                var seekingTo = this.getSeekableRange() ? this._getClampedTimeForPlayFrom(seconds) : seconds;
                 
                 //StartPlayback from live position 0 causes spoiler defect
                 if (seekingTo === 0 && this._isLiveMedia()) {
@@ -355,7 +355,15 @@ require.def(
             * @inheritDoc
             */
             getSeekableRange: function () {
-                return this._range;
+                switch (this.getState()) {
+                case MediaPlayer.STATE.STOPPED:
+                case MediaPlayer.STATE.ERROR:
+                    break;
+
+                default:
+                    return this._range;
+                }
+                return undefined;
             },
             
             _isLiveRangeOutdated: function () {

--- a/static/script/devices/mediaplayer/samsung_streaming.js
+++ b/static/script/devices/mediaplayer/samsung_streaming.js
@@ -4,14 +4,14 @@
  */
 
 require.def(
-    "antie/devices/mediaplayer/samsung_streaming",
+    'antie/devices/mediaplayer/samsung_streaming',
     [
-        "antie/devices/device",
-        "antie/devices/mediaplayer/mediaplayer",
-        "antie/runtimecontext"
+        'antie/devices/device',
+        'antie/devices/mediaplayer/mediaplayer',
+        'antie/runtimecontext'
     ],
     function(Device, MediaPlayer, RuntimeContext) {
-        "use strict";
+        'use strict';
 
         /**
          * MediaPlayer implementation for Samsung devices supporting HLS Live Seek implementing the Streaming API.
@@ -83,10 +83,10 @@ require.def(
 
                     if (this._isHlsMimeType()) {
                         if (this._isLiveMedia()) {
-                            this._source += "|HLSSLIDING|COMPONENT=HLS";
+                            this._source += '|HLSSLIDING|COMPONENT=HLS';
                             this._openStreamingPlayerPlugin();
                         } else {
-                            this._source += "|COMPONENT=HLS";
+                            this._source += '|COMPONENT=HLS';
                             this._openPlayerPlugin();
                         }
                     } else {
@@ -96,7 +96,7 @@ require.def(
                     this._initPlayer(this._source);
 
                 } else {
-                    this._toError("Cannot set source unless in the '" + MediaPlayer.STATE.EMPTY + "' state");
+                    this._toError('Cannot set source unless in the \'' + MediaPlayer.STATE.EMPTY + '\' state');
                 }
             },
 
@@ -117,7 +117,7 @@ require.def(
                 if (this._currentPlayer !== undefined) {
                     this._playerPlugin.Close();
                 }
-                this._playerPlugin.Open("Player", "1.010", "Player");
+                this._playerPlugin.Open('Player', '1.010', 'Player');
                 this._currentPlayer = this.PlayerEmps.Player;
             },
             
@@ -125,7 +125,7 @@ require.def(
                 if (this._currentPlayer !== undefined) {
                     this._playerPlugin.Close();
                 }
-                this._playerPlugin.Open("StreamingPlayer", "1.0", "StreamingPlayer");
+                this._playerPlugin.Open('StreamingPlayer', '1.0', 'StreamingPlayer');
                 this._currentPlayer = this.PlayerEmps.StreamingPlayer;
             },
             
@@ -135,10 +135,10 @@ require.def(
             },
 
             _initPlayer: function(source) {
-                var result = this._playerPlugin.Execute("InitPlayer", source);
+                var result = this._playerPlugin.Execute('InitPlayer', source);
                 
                 if (result !== 1) {
-                    this._toError("Failed to initialize video: " + this._source);
+                    this._toError('Failed to initialize video: ' + this._source);
                 }
             },
 
@@ -148,25 +148,25 @@ require.def(
             resume : function () {
                 this._postBufferingState = MediaPlayer.STATE.PLAYING;
                 switch (this.getState()) {
-                    case MediaPlayer.STATE.PLAYING:
-                        break;
+                case MediaPlayer.STATE.PLAYING:
+                    break;
 
-                    case MediaPlayer.STATE.BUFFERING:
-                        if (this._tryingToPause) {
-                            this._tryingToPause = false;
-                            this._toPlaying();
-                        }
-                        break;
-
-                    case MediaPlayer.STATE.PAUSED:
-                        var result = this._playerPlugin.Execute("Resume");
-
+                case MediaPlayer.STATE.BUFFERING:
+                    if (this._tryingToPause) {
+                        this._tryingToPause = false;
                         this._toPlaying();
-                        break;
+                    }
+                    break;
 
-                    default:
-                        this._toError("Cannot resume while in the '" + this.getState() + "' state");
-                        break;
+                case MediaPlayer.STATE.PAUSED:
+                    this._playerPlugin.Execute('Resume');
+
+                    this._toPlaying();
+                    break;
+
+                default:
+                    this._toError('Cannot resume while in the \'' + this.getState() + '\' state');
+                    break;
                 }
             },
 
@@ -178,46 +178,46 @@ require.def(
                 var seekingTo = this._range ? this._getClampedTimeForPlayFrom(seconds) : seconds;             
                 
                 switch (this.getState()) {
-                    case MediaPlayer.STATE.BUFFERING:
+                case MediaPlayer.STATE.BUFFERING:
 //                        this._deferSeekingTo = seekingTo;
-                        this._nextSeekingTo = seekingTo;
-                        break;
+                    this._nextSeekingTo = seekingTo;
+                    break;
 
-                    case MediaPlayer.STATE.PLAYING:
-                        this._toBuffering();
-                        if (!this._currentTimeKnown) {
-                            this._deferSeekingTo = seekingTo;
-                        } else if (this._isNearToCurrentTime(seekingTo)) {
-                            this._toPlaying();
-                        } else {
-                            this._seekToWithFailureStateTransition(seekingTo);
-                        }
-                        break;
+                case MediaPlayer.STATE.PLAYING:
+                    this._toBuffering();
+                    if (!this._currentTimeKnown) {
+                        this._deferSeekingTo = seekingTo;
+                    } else if (this._isNearToCurrentTime(seekingTo)) {
+                        this._toPlaying();
+                    } else {
+                        this._seekToWithFailureStateTransition(seekingTo);
+                    }
+                    break;
 
 
-                    case MediaPlayer.STATE.PAUSED:
-                        this._toBuffering();
-                        if (!this._currentTimeKnown) {
-                            this._deferSeekingTo = seekingTo;
-                        } else if (this._isNearToCurrentTime(seekingTo)) {
-                            var result = this._playerPlugin.Execute("Resume");
-                            this._toPlaying();
-                        } else {
-                            this._seekToWithFailureStateTransition(seekingTo);
-                            var result = this._playerPlugin.Execute("Resume");
-                        }
-                        break;
+                case MediaPlayer.STATE.PAUSED:
+                    this._toBuffering();
+                    if (!this._currentTimeKnown) {
+                        this._deferSeekingTo = seekingTo;
+                    } else if (this._isNearToCurrentTime(seekingTo)) {
+                        this._playerPlugin.Execute('Resume');
+                        this._toPlaying();
+                    } else {
+                        this._seekToWithFailureStateTransition(seekingTo);
+                        this._playerPlugin.Execute('Resume');
+                    }
+                    break;
 
-                    case MediaPlayer.STATE.COMPLETE:
-                        var result = this._playerPlugin.Execute("Stop");
-                        this._initPlayer(this._source);
-                        var result = this._playerPlugin.Execute("StartPlayback", seekingTo);
-                        this._toBuffering();
-                        break;
+                case MediaPlayer.STATE.COMPLETE:
+                    this._playerPlugin.Execute('Stop');
+                    this._initPlayer(this._source);
+                    this._playerPlugin.Execute('StartPlayback', seekingTo);
+                    this._toBuffering();
+                    break;
 
-                    default:
-                        this._toError("Cannot playFrom while in the '" + this.getState() + "' state");
-                        break;
+                default:
+                    this._toError('Cannot playFrom while in the \'' + this.getState() + '\' state');
+                    break;
                 }
             },
 
@@ -227,14 +227,14 @@ require.def(
             beginPlayback: function() {
                 this._postBufferingState = MediaPlayer.STATE.PLAYING;
                 switch (this.getState()) {
-                    case MediaPlayer.STATE.STOPPED:
-                        this._toBuffering();
-                        var result = this._playerPlugin.Execute("StartPlayback");
-                        break;
+                case MediaPlayer.STATE.STOPPED:
+                    this._toBuffering();
+                    this._playerPlugin.Execute('StartPlayback');
+                    break;
 
-                    default:
-                        this._toError("Cannot beginPlayback while in the '" + this.getState() + "' state");
-                        break;
+                default:
+                    this._toError('Cannot beginPlayback while in the \'' + this.getState() + '\' state');
+                    break;
                 }
             },
 
@@ -253,15 +253,15 @@ require.def(
                 }
 
                 switch (this.getState()) {
-                    case MediaPlayer.STATE.STOPPED:
-                        var success = this._playerPlugin.Execute("StartPlayback", seekingTo);
+                case MediaPlayer.STATE.STOPPED:
+                    this._playerPlugin.Execute('StartPlayback', seekingTo);
 
-                        this._toBuffering();
-                        break;
+                    this._toBuffering();
+                    break;
 
-                    default:
-                        this._toError("Cannot beginPlayback while in the '" + this.getState() + "' state");
-                        break;
+                default:
+                    this._toError('Cannot beginPlayback while in the \'' + this.getState() + '\' state');
+                    break;
                 }
             },
 
@@ -271,17 +271,17 @@ require.def(
             pause: function () {
                 this._postBufferingState = MediaPlayer.STATE.PAUSED;
                 switch (this.getState()) {
-                    case MediaPlayer.STATE.BUFFERING:
-                    case MediaPlayer.STATE.PAUSED:
-                        break;
+                case MediaPlayer.STATE.BUFFERING:
+                case MediaPlayer.STATE.PAUSED:
+                    break;
 
-                    case MediaPlayer.STATE.PLAYING:
-                        this._tryPauseWithStateTransition();
-                        break;
+                case MediaPlayer.STATE.PLAYING:
+                    this._tryPauseWithStateTransition();
+                    break;
 
-                    default:
-                        this._toError("Cannot pause while in the '" + this.getState() + "' state");
-                        break;
+                default:
+                    this._toError('Cannot pause while in the \'' + this.getState() + '\' state');
+                    break;
                 }
             },
 
@@ -290,20 +290,20 @@ require.def(
             */
             stop: function () {
                 switch (this.getState()) {
-                    case MediaPlayer.STATE.STOPPED:
-                        break;
+                case MediaPlayer.STATE.STOPPED:
+                    break;
 
-                    case MediaPlayer.STATE.BUFFERING:
-                    case MediaPlayer.STATE.PLAYING:
-                    case MediaPlayer.STATE.PAUSED:
-                    case MediaPlayer.STATE.COMPLETE:
-                        this._stopPlayer();
-                        this._toStopped();
-                        break;
+                case MediaPlayer.STATE.BUFFERING:
+                case MediaPlayer.STATE.PLAYING:
+                case MediaPlayer.STATE.PAUSED:
+                case MediaPlayer.STATE.COMPLETE:
+                    this._stopPlayer();
+                    this._toStopped();
+                    break;
 
-                    default:
-                        this._toError("Cannot stop while in the '" + this.getState() + "' state");
-                        break;
+                default:
+                    this._toError('Cannot stop while in the \'' + this.getState() + '\' state');
+                    break;
                 }
             },
 
@@ -312,17 +312,17 @@ require.def(
             */
             reset: function () {
                 switch (this.getState()) {
-                    case MediaPlayer.STATE.EMPTY:
-                        break;
+                case MediaPlayer.STATE.EMPTY:
+                    break;
 
-                    case MediaPlayer.STATE.STOPPED:
-                    case MediaPlayer.STATE.ERROR:
-                        this._toEmpty();
-                        break;
+                case MediaPlayer.STATE.STOPPED:
+                case MediaPlayer.STATE.ERROR:
+                    this._toEmpty();
+                    break;
 
-                    default:
-                        this._toError("Cannot reset while in the '" + this.getState() + "' state");
-                        break;
+                default:
+                    this._toError('Cannot reset while in the \'' + this.getState() + '\' state');
+                    break;
                 }
             },
 
@@ -426,13 +426,13 @@ require.def(
             },
 
             _stopPlayer: function() {
-                var result = this._playerPlugin.Execute("Stop");
+                this._playerPlugin.Execute('Stop');
 
                 this._currentTimeKnown = false;
             },
 
             _tryPauseWithStateTransition: function() {                
-                var success = this._playerPlugin.Execute("Pause");
+                var success = this._playerPlugin.Execute('Pause');
                 success = success && (success !== -1);
 
                 if (success) {
@@ -452,7 +452,7 @@ require.def(
             _updateRange: function () {
                 var self = this;
                 if (this._currentPlayer === this.PlayerEmps.StreamingPlayer) {
-                    var range = this._playerPlugin.Execute("GetPlayingRange").split('-');
+                    var range = this._playerPlugin.Execute('GetPlayingRange').split('-');
                     this._range = {
                         start: Math.floor(range[0]),
                         end: Math.floor(range[1])
@@ -463,11 +463,11 @@ require.def(
                         self._updatingTime = false;
                     }, self.RANGE_UPDATE_TOLERANCE * 1000);
                 } else if (this._currentPlayer === this.PlayerEmps.Player) {
-                    var duration = this._playerPlugin.Execute("GetDuration")/1000;
+                    var duration = this._playerPlugin.Execute('GetDuration')/1000;
                     this._range = {
                         start: 0,
                         end: duration
-                    }
+                    };
                 }
             },
 
@@ -520,7 +520,7 @@ require.def(
                 }
                 var clampedTime = this._getClampedTime(seconds);
                 if (clampedTime !== seconds) {
-                    RuntimeContext.getDevice().getLogger().debug("playFrom " + seconds+ " clamped to " + clampedTime + " - seekable range is { start: " + this._range.start + ", end: " + this._range.end + " }");
+                    RuntimeContext.getDevice().getLogger().debug('playFrom ' + seconds+ ' clamped to ' + clampedTime + ' - seekable range is { start: ' + this._range.start + ', end: ' + this._range.end + ' }');
                 }
                 return clampedTime;
             },
@@ -543,73 +543,73 @@ require.def(
 
             _registerEventHandlers: function() {
                 var self = this;
-                this._playerPlugin.OnEvent = function(eventType, param1, param2) {
+                this._playerPlugin.OnEvent = function(eventType, param1/*, param2*/) {
 
                     if (eventType !== self.PlayerEventCodes.CURRENT_PLAYBACK_TIME) {
-                        //self._logger.info("Received event " + eventType + ' ' + param1);
+                        //self._logger.info('Received event ' + eventType + ' ' + param1);
                     }
 
                     switch (eventType) {
 
-                        case self.PlayerEventCodes.STREAM_INFO_READY:
-                            self._updateRange()
-                            break;
+                    case self.PlayerEventCodes.STREAM_INFO_READY:
+                        self._updateRange();
+                        break;
 
-                        case self.PlayerEventCodes.CURRENT_PLAYBACK_TIME:
-                            if (self._range && self._isLiveMedia()) {
-                                var seconds = Math.floor(param1/1000);
-                                //jump to previous current time if PTS out of range occurs
-                                if (seconds > self._range.end + self.RANGE_END_TOLERANCE) {
-                                    self.playFrom(self._currentTime);
-                                    break;
-                                //call GetPlayingRange() on SEF emp if current time is out of range
-                                } else if (!self._isCurrentTimeInRangeTolerance(seconds)) {
-                                    self._updateRange();
-                                }
+                    case self.PlayerEventCodes.CURRENT_PLAYBACK_TIME:
+                        if (self._range && self._isLiveMedia()) {
+                            var seconds = Math.floor(param1/1000);
+                            //jump to previous current time if PTS out of range occurs
+                            if (seconds > self._range.end + self.RANGE_END_TOLERANCE) {
+                                self.playFrom(self._currentTime);
+                                break;
+                            //call GetPlayingRange() on SEF emp if current time is out of range
+                            } else if (!self._isCurrentTimeInRangeTolerance(seconds)) {
+                                self._updateRange();
                             }
-                            self._onCurrentTime(param1);
-                            break;
+                        }
+                        self._onCurrentTime(param1);
+                        break;
 
-                        case self.PlayerEventCodes.BUFFERING_START:
-                        case self.PlayerEventCodes.BUFFERING_PROGRESS:
-                            self._onDeviceBuffering();
-                            break;
+                    case self.PlayerEventCodes.BUFFERING_START:
+                    case self.PlayerEventCodes.BUFFERING_PROGRESS:
+                        self._onDeviceBuffering();
+                        break;
 
-                        case self.PlayerEventCodes.BUFFERING_COMPLETE:
-                            //[optimisation] if Stop() is not called after RENDERING_COMPLETE then player sends periodically BUFFERING_COMPLETE and RENDERING_COMPLETE
-                            //ignore BUFFERING_COMPLETE if player is already in COMPLETE state
-                            if (self.getState() !== MediaPlayer.STATE.COMPLETE) {
-                                self._onFinishedBuffering();
-                            }
-                            break;
+                    case self.PlayerEventCodes.BUFFERING_COMPLETE:
+                        //[optimisation] if Stop() is not called after RENDERING_COMPLETE then player sends periodically BUFFERING_COMPLETE and RENDERING_COMPLETE
+                        //ignore BUFFERING_COMPLETE if player is already in COMPLETE state
+                        if (self.getState() !== MediaPlayer.STATE.COMPLETE) {
+                            self._onFinishedBuffering();
+                        }
+                        break;
 
-                        case self.PlayerEventCodes.RENDERING_COMPLETE:
-                            //[optimisation] if Stop() is not called after RENDERING_COMPLETE then player sends periodically BUFFERING_COMPLETE and RENDERING_COMPLETE
-                            //ignore RENDERING_COMPLETE if player is already in COMPLETE state
-                            if (self.getState() !== MediaPlayer.STATE.COMPLETE) {
-                                self._onEndOfMedia();
-                            }
-                            break;
+                    case self.PlayerEventCodes.RENDERING_COMPLETE:
+                        //[optimisation] if Stop() is not called after RENDERING_COMPLETE then player sends periodically BUFFERING_COMPLETE and RENDERING_COMPLETE
+                        //ignore RENDERING_COMPLETE if player is already in COMPLETE state
+                        if (self.getState() !== MediaPlayer.STATE.COMPLETE) {
+                            self._onEndOfMedia();
+                        }
+                        break;
 
-                        case self.PlayerEventCodes.CONNECTION_FAILED:
-                            self._onDeviceError("Media element emitted OnConnectionFailed");
-                            break;
-                            
-                        case self.PlayerEventCodes.NETWORK_DISCONNECTED:
-                            self._onDeviceError("Media element emitted OnNetworkDisconnected");
-                            break;
+                    case self.PlayerEventCodes.CONNECTION_FAILED:
+                        self._onDeviceError('Media element emitted OnConnectionFailed');
+                        break;
 
-                        case self.PlayerEventCodes.AUTHENTICATION_FAILED:
-                            self._onDeviceError("Media element emitted OnAuthenticationFailed");
-                            break;
+                    case self.PlayerEventCodes.NETWORK_DISCONNECTED:
+                        self._onDeviceError('Media element emitted OnNetworkDisconnected');
+                        break;
 
-                        case self.PlayerEventCodes.RENDER_ERROR:
-                            self._onDeviceError("Media element emitted OnRenderError");
-                            break;
+                    case self.PlayerEventCodes.AUTHENTICATION_FAILED:
+                        self._onDeviceError('Media element emitted OnAuthenticationFailed');
+                        break;
 
-                        case self.PlayerEventCodes.STREAM_NOT_FOUND:
-                            self._onDeviceError("Media element emitted OnStreamNotFound");
-                            break;
+                    case self.PlayerEventCodes.RENDER_ERROR:
+                        self._onDeviceError('Media element emitted OnRenderError');
+                        break;
+
+                    case self.PlayerEventCodes.STREAM_NOT_FOUND:
+                        self._onDeviceError('Media element emitted OnStreamNotFound');
+                        break;
                     }
                 };
 
@@ -619,9 +619,6 @@ require.def(
 
                 window.addEventListener('hide', this._onWindowHide, false);
                 window.addEventListener('unload', this._onWindowHide, false);
-            },
-            _handlePlaying : function() {
-                this.bubbleEvent(new MediaEvent("playing", this));
             },
 
             _unregisterEventHandlers: function() {
@@ -666,18 +663,19 @@ require.def(
             },
 
             _jump: function (offsetSeconds) {
+                var result;
                 if (offsetSeconds > 0) {
-                    var result = this._playerPlugin.Execute("JumpForward", offsetSeconds);
+                    result = this._playerPlugin.Execute('JumpForward', offsetSeconds);
                     return result;
                 } else {
-                    var result = this._playerPlugin.Execute("JumpBackward", Math.abs(offsetSeconds));
+                    result = this._playerPlugin.Execute('JumpBackward', Math.abs(offsetSeconds));
                     return result;
                 }
             },
 
             _isHlsMimeType: function () {
                 var mime = this._mimeType.toLowerCase();
-                return mime === "application/vnd.apple.mpegurl" || mime === "application/x-mpegurl";
+                return mime === 'application/vnd.apple.mpegurl' || mime === 'application/x-mpegurl';
             },
             
             _isCurrentTimeInRangeTolerance: function (seconds) {
@@ -739,7 +737,7 @@ require.def(
                 this._wipe();
                 this._state = MediaPlayer.STATE.ERROR;
                 this._reportError(errorMessage);
-                throw "ApiError: " + errorMessage;
+                throw 'ApiError: ' + errorMessage;
             },
 
             /**

--- a/static/script/devices/mediaplayer/samsung_streaming.js
+++ b/static/script/devices/mediaplayer/samsung_streaming.js
@@ -35,11 +35,11 @@ require.def(
         "use strict";
 
         /**
-         * Main MediaPlayer implementation for Samsung devices implementing the Maple API.
+         * MediaPlayer implementation for Samsung devices supporting HLS Live Seek implementing the Maple API.
          * Use this device modifier if a device implements the Samsung Maple media playback standard.
          * It must support creation of &lt;object&gt; elements with appropriate SAMSUNG_INFOLINK classids.
          * Those objects must expose an API in accordance with the Samsung Maple media specification.
-         * @name antie.devices.mediaplayer.SamsungMaple
+         * @name antie.devices.mediaplayer.SamsungStreaming
          * @class
          * @extends antie.devices.mediaplayer.MediaPlayer
          */
@@ -66,14 +66,22 @@ require.def(
                 SUBTITLE : 19,
                 CUSTOM : 20
             },
+            PlayerEmps: {
+                Player : 0,
+                StreamingPlayer : 1
+            },
 
             init: function() {
                 this._super();
                 this._state = MediaPlayer.STATE.EMPTY;
+                this._currentPlayer = undefined;
                 this._deferSeekingTo = null;
+                this._nextSeekingTo = null;
                 this._postBufferingState = null;
                 this._tryingToPause = false;
                 this._currentTimeKnown = false;
+                this._updatingTime = false;
+                this._lastWindowRanged = false;
 
                 try {
                     this._registerSamsungPlugins();
@@ -95,14 +103,16 @@ require.def(
                     this._registerEventHandlers();
                     this._toStopped();
 
-
-                    // this.logger.info('setSource(): ' + mediaType);
-
-                    if (mediaType === 'live-video') {
-                    //    this.logger.info("recognised live video, appending URL");
-                        this._source += "|HLSSLIDING|COMPONENT=HLS";
+                    if (this._isHlsMimeType()) {
+                        if (this._isLiveMedia()) {
+                            this._source += "|HLSSLIDING|COMPONENT=HLS";
+                            this._openStreamingPlayerPlugin();
+                        } else {
+                            this._source += "|COMPONENT=HLS";
+                            this._openPlayerPlugin();
+                        }
                     } else {
-                        this._source += "|COMPONENT=HLS";       //<TODO> is this correct for VOD HLS?
+                        this._openPlayerPlugin();
                     }
 
                     this._initPlayer(this._source);
@@ -116,8 +126,6 @@ require.def(
                 var self = this;
                 this._playerPlugin = document.getElementById('sefPlayer');
 
-                this._playerPlugin.Open("StreamingPlayer", "1.0", "StreamingPlayer");
-
                 this.tvmwPlugin = document.getElementById('pluginObjectTVMW');
 
                 this.originalSource = this.tvmwPlugin.GetSource();
@@ -126,27 +134,34 @@ require.def(
                     self.tvmwPlugin.SetSource(self.originalSource);
                 }, false);
             },
+            
+            _openPlayerPlugin : function() {
+                if (this._currentPlayer !== undefined) {
+                    this._playerPlugin.Close();
+                }
+                this._playerPlugin.Open("Player", "1.010", "Player");
+                this._currentPlayer = this.PlayerEmps.Player;
+            },
+            
+            _openStreamingPlayerPlugin : function() {
+                if (this._currentPlayer !== undefined) {
+                    this._playerPlugin.Close();
+                }
+                this._playerPlugin.Open("StreamingPlayer", "1.0", "StreamingPlayer");
+                this._currentPlayer = this.PlayerEmps.StreamingPlayer;
+            },
+            
+            _closePlugin: function() {
+                this._playerPlugin.Close();
+                this._currentPlayer = undefined;
+            },
 
             _initPlayer: function(source) {
-                this.logger.info('Calling this.playerPlugin.Execute("InitPlayer", ' + this._source + ')');
                 var result = this._playerPlugin.Execute("InitPlayer", source);
-                if (result === -1) {
-                    this._toError('STOP');
-                    return;
+                
+                if (result !== 1) {
+                    this._toError("Failed to initialize video: " + this._source);
                 }
-                this.logger.info('InitPlayer responded with ' + result);
-
-                this.logger.info('Calling this.playerPlugin.Execute("SetTotalBufferSize", ' +  32 *1024*1024 + ')');
-                result = this._playerPlugin.Execute("SetTotalBufferSize", 32 *1024*1024);
-                this.logger.info('SetTotalBufferSize responded with ' + result);
-
-                this.logger.info('Calling this.playerPlugin.Execute("SetInitialBufferSize", ' +  32 *1024*1024 + ')');
-                result = this._playerPlugin.Execute("SetInitialBufferSize", 32 *1024*1024);
-                this.logger.info('SetInitialBufferSize responded with ' + result);
-
-                this.logger.info('Calling this.playerPlugin.Execute("SetPendingBuffer", ' +  32 *1024*1024 + ')');
-                result = this._playerPlugin.Execute("SetPendingBuffer", 32 *1024*1024);
-                this.logger.info('InitPlayer responded with ' + result);
             },
 
             /**
@@ -166,9 +181,7 @@ require.def(
                         break;
 
                     case MediaPlayer.STATE.PAUSED:
-                        this.logger.info('calling this._playerPlugin.Execute("Resume")');
                         var result = this._playerPlugin.Execute("Resume");
-                        this.logger.info('Resume responded with ' + result);
 
                         this._toPlaying();
                         break;
@@ -184,11 +197,12 @@ require.def(
             */
             playFrom: function (seconds) {
                 this._postBufferingState = MediaPlayer.STATE.PLAYING;
-                var seekingTo = this._range ? this._getClampedTimeForPlayFrom(seconds) : seconds;
-
+                var seekingTo = this._range ? this._getClampedTimeForPlayFrom(seconds) : seconds;             
+                
                 switch (this.getState()) {
                     case MediaPlayer.STATE.BUFFERING:
-                        this._deferSeekingTo = seekingTo;
+//                        this._deferSeekingTo = seekingTo;
+                        this._nextSeekingTo = seekingTo;
                         break;
 
                     case MediaPlayer.STATE.PLAYING:
@@ -208,30 +222,18 @@ require.def(
                         if (!this._currentTimeKnown) {
                             this._deferSeekingTo = seekingTo;
                         } else if (this._isNearToCurrentTime(seekingTo)) {
-                            this.logger.info('Calling this._playerPlugin.Execute("Resume")');
                             var result = this._playerPlugin.Execute("Resume");
-                            this.logger.info('"Resume" responded with ' + result);
                             this._toPlaying();
                         } else {
                             this._seekToWithFailureStateTransition(seekingTo);
-                            this.logger.info('Calling this._playerPlugin.Execute("Resume")');
                             var result = this._playerPlugin.Execute("Resume");
-                            this.logger.info('"Resume" responded with ' + result);
                         }
                         break;
 
                     case MediaPlayer.STATE.COMPLETE:
-                        this.logger.info('Calling this.playerPlugin.Execute("Stop");');
                         var result = this._playerPlugin.Execute("Stop");
-                        this.logger.info('"Stop" responded with ' + result);
-
-                        //this._setDisplayFullScreenForVideo();
-                        //this._playerPlugin.ResumePlay(this._wrappedSource(), seekingTo);
-
-                        this.logger.info('Calling this.playerPlugin.Execute("StartPlayback");');
+                        this._initPlayer(this._source);
                         var result = this._playerPlugin.Execute("StartPlayback", seekingTo);
-                        this.logger.info('"StartPlayback" responded with ' + result);
-
                         this._toBuffering();
                         break;
 
@@ -249,12 +251,7 @@ require.def(
                 switch (this.getState()) {
                     case MediaPlayer.STATE.STOPPED:
                         this._toBuffering();
-                        //this._setDisplayFullScreenForVideo();
-                        //this._playerPlugin.Play(this._wrappedSource());
-                        this.logger.info('Calling this.playerPlugin.Execute("StartPlayback")');
                         var result = this._playerPlugin.Execute("StartPlayback");
-                        this.logger.info('"StartPlayback" responded with ' + result);
-
                         break;
 
                     default:
@@ -267,23 +264,19 @@ require.def(
              * @inheritDoc
              */
             beginPlaybackFrom: function(seconds) {
-                // this.logger.info('beginPlaybackFrom:'+seconds);
-
                 this._postBufferingState = MediaPlayer.STATE.PLAYING;
                 var seekingTo = this._range ? this._getClampedTimeForPlayFrom(seconds) : seconds;
-                seekingTo = parseInt(Math.floor(seekingTo), 10);
-
-                this._targetSeekTime = seekingTo;
+                
+                //StartPlayback from live position 0 causes spoiler defect
+                if (seekingTo === 0 && this._isLiveMedia()) {
+                    seekingTo = this.CLAMP_OFFSET_FROM_END_OF_RANGE;
+                } else {
+                    seekingTo = parseInt(Math.floor(seekingTo), 10);
+                }
 
                 switch (this.getState()) {
                     case MediaPlayer.STATE.STOPPED:
-
-                        //this._setDisplayFullScreenForVideo();
-                        //this._playerPlugin.ResumePlay(this._wrappedSource(), seekingTo);
-
-                        this.logger.info('Calling this.playerPlugin.Execute("StartPlayback")');
                         var success = this._playerPlugin.Execute("StartPlayback", seekingTo);
-                        this.logger.info('"StartPlayback" responded with ' + success);
 
                         this._toBuffering();
                         break;
@@ -386,6 +379,16 @@ require.def(
             getSeekableRange: function () {
                 return this._range;
             },
+            
+            isLiveRangeOutdated: function () {
+                var time = Math.floor(this._currentTime);
+                if (time % 8 === 0 && !this._updatingTime && this._lastWindowRanged !== time) {
+                    this._lastWindowRanged = time;
+                    return true;
+                } else {
+                    return false;
+                }
+            },
 
             /**
              * @inheritDoc
@@ -415,6 +418,11 @@ require.def(
                 if (this.getState() !== MediaPlayer.STATE.BUFFERING) {
                     return;
                 }
+                
+                if (!this._isInitialBufferingFinished() && this._nextSeekingTo !== null) {
+                    this._deferSeekingTo = this._nextSeekingTo;
+                    this._nextSeekingTo = null;
+                }
 
                 if (this._deferSeekingTo === null) {
                     if (this._postBufferingState === MediaPlayer.STATE.PAUSED) {
@@ -440,17 +448,13 @@ require.def(
             },
 
             _stopPlayer: function() {
-                this.logger.info('Calling this.playerPlugin.Execute("Stop")');
                 var result = this._playerPlugin.Execute("Stop");
-                this.logger.info('"Stop" responded with ' + result);
 
                 this._currentTimeKnown = false;
             },
 
             _tryPauseWithStateTransition: function() {
-                this.logger.info('Calling this.playerPlugin.Execute("Pause")');
                 var success = this._isSuccessCode(this._playerPlugin.Execute("Pause"));
-                this.logger.info('"Pause" responded with ' + success);
 
                 if (success) {
                     this._toPaused();
@@ -465,48 +469,50 @@ require.def(
                     this._emitEvent(MediaPlayer.EVENT.STATUS);
                 }
             },
-
-            _onMetadata: function() {
-                this.logger.info('Calling this.playerPlugin.Execute("GetPlayingRange")');
-                var range = this._playerPlugin.Execute("GetPlayingRange").split('-');
-                this._range = {
-                    start: range[0],
-                    end: range[1]
-                };
-
-                this.logger.info('Current Duration ' + this._range.end * 1000 + 'ms');
-
-                // this.logger.info("_onMetadata range = {0, "  + this._range.end);
-                // this.logger.info("this._currentTime = " + this._currentTime);       //<TODO> so currentTime is currently in milliseconds relative to midnight! and not to hls window
-
-                if (this._waitingToPlayFrom()) {
-                    this._deferredPlayFrom();
+            
+            _updateRange: function () {
+                var self = this;
+                if (this._currentPlayer === this.PlayerEmps.StreamingPlayer) {
+                    var range = this._playerPlugin.Execute("GetPlayingRange").split('-');
+                    this._range = {
+                        start: Math.floor(range[0]),
+                        end: Math.floor(range[1])
+                    };
+                    //don't call range for the next 8 seconds
+                    this._updatingTime = true;
+                    setTimeout(function () {
+                        self._updatingTime = false;
+                    }, self.RANGE_UPDATE_TOLERANCE * 1000);
+                } else if (this._currentPlayer === this.PlayerEmps.Player) {
+                    var duration = this._playerPlugin.Execute("GetDuration")/1000;
+                    this._range = {
+                        start: 0,
+                        end: duration
+                    }
                 }
-
-                this._onFinishedBuffering();
-            },
-
-            _waitingToPlayFrom: function() {
-                return this._targetSeekTime !== undefined;
-            },
-
-            _deferredPlayFrom: function() {
-                this._seekTo(this._targetSeekTime);
-
-                if (this._postBufferingState === MediaPlayer.STATE.PAUSED) {
-                    this._tryPauseWithStateTransition();
-                }
-                this._targetSeekTime = undefined;
             },
 
 
             _onCurrentTime: function(timeInMillis) {
 
-                //this.logger.info("_onCurrentTime "  + timeInMillis);
+                //this.logger.info("_onCurrentTime: "  + timeInMillis);
 
                 this._currentTime = timeInMillis / 1000;
                 this._onStatus();
                 this._currentTimeKnown = true;
+
+                //[optimisation] do not call player API periodically in HLS live
+                // - calculate range manually when possible
+                // - do not calculate range if player API was called less than RANGE_UPDATE_TOLERANCE seconds ago
+                if (this._isLiveMedia() && this.isLiveRangeOutdated()) {
+                    this._range.start += 8;
+                    this._range.end += 8;
+                }
+                
+                if (this._nextSeekingTo !== null) {
+                    this._deferSeekingTo = this._nextSeekingTo;
+                    this._nextSeekingTo = null;
+                }
 
                 if (this._deferSeekingTo !== null) {
                     this._deferredSeek();
@@ -533,11 +539,30 @@ require.def(
             },
 
             _getClampedTimeForPlayFrom: function (seconds) {
+                if (this._currentPlayer === this.PlayerEmps.StreamingPlayer && !this._updatingTime) {
+                    this._updateRange();
+                }
                 var clampedTime = this._getClampedTime(seconds);
                 if (clampedTime !== seconds) {
                     RuntimeContext.getDevice().getLogger().debug("playFrom " + seconds+ " clamped to " + clampedTime + " - seekable range is { start: " + this._range.start + ", end: " + this._range.end + " }");
                 }
                 return clampedTime;
+            },
+            
+            _getClampOffsetFromConfig: function() {
+                var clampOffsetFromEndOfRange;
+                var config = RuntimeContext.getDevice().getConfig();
+                if (config && config.streaming && config.streaming.overrides) {
+                    clampOffsetFromEndOfRange = config.streaming.overrides.clampOffsetFromEndOfRange;
+                }
+
+                if(clampOffsetFromEndOfRange !== undefined) {
+                    return clampOffsetFromEndOfRange;
+                } else if (this._isLiveMedia()) {
+                    return this.CLAMP_OFFSET_FROM_END_OF_LIVE_RANGE;
+                } else {
+                    return this.CLAMP_OFFSET_FROM_END_OF_RANGE;
+                }
             },
 
             _registerEventHandlers: function() {
@@ -545,24 +570,29 @@ require.def(
                 this._playerPlugin.OnEvent = function(eventType, param1, param2) {
 
                     if (eventType !== self.PlayerEventCodes.CURRENT_PLAYBACK_TIME) {
-                        self.logger.info("Received event " + eventType + ' ' + param1);
+                        //self.logger.info("Received event " + eventType + ' ' + param1);
                     }
 
                     switch (eventType) {
 
                         case self.PlayerEventCodes.STREAM_INFO_READY:
-                            self._onMetadata();
+                            self._updateRange()
                             break;
 
                         case self.PlayerEventCodes.CURRENT_PLAYBACK_TIME:
-                            self._onCurrentTime(param1);
-                            //<TODO> use only in LIVE scenario
-                            if (Math.floor(param1/1000) % 8 === 0 && self._state !== MediaPlayer.STATE.STOPPED) {
-                                self._onMetadata();
+                            if (self._range && self._isLiveMedia()) {
+                                var seconds = Math.floor(param1/1000);
+                                //jump to previous current time if PTS out of range occurs
+                                if (seconds > self._range.end + self.RANGE_END_TOLERANCE) {
+                                    self.playFrom(self._currentTime);
+                                    break;
+                                //call GetPlayingRange() on SEF emp if current time is out of range
+                                } else if (!self._isCurrentTimeInRangeTolerance(seconds)) {
+                                    self._updateRange();
+                                }
                             }
+                            self._onCurrentTime(param1);
                             break;
-
-                        // All these below doesn't seem to be implemented for HLS? I certainly have not seen any of these being logged....
 
                         case self.PlayerEventCodes.BUFFERING_START:
                         case self.PlayerEventCodes.BUFFERING_PROGRESS:
@@ -570,27 +600,39 @@ require.def(
                             break;
 
                         case self.PlayerEventCodes.BUFFERING_COMPLETE:
-                            self._onFinishedBuffering();
+                            //[optimisation] if Stop() is not called after RENDERING_COMPLETE then player sends periodically BUFFERING_COMPLETE and RENDERING_COMPLETE
+                            //ignore BUFFERING_COMPLETE if player is already in COMPLETE state
+                            if (self.getState() !== MediaPlayer.STATE.COMPLETE) {
+                                self._onFinishedBuffering();
+                            }
                             break;
 
                         case self.PlayerEventCodes.RENDERING_COMPLETE:
-                            self._onEndOfMedia();
+                            //[optimisation] if Stop() is not called after RENDERING_COMPLETE then player sends periodically BUFFERING_COMPLETE and RENDERING_COMPLETE
+                            //ignore RENDERING_COMPLETE if player is already in COMPLETE state
+                            if (self.getState() !== MediaPlayer.STATE.COMPLETE) {
+                                self._onEndOfMedia();
+                            }
                             break;
 
                         case self.PlayerEventCodes.CONNECTION_FAILED:
-                            self._onDeviceError("Connection failed");
+                            self._onDeviceError("Media element emitted OnConnectionFailed");
+                            break;
+                            
+                        case self.PlayerEventCodes.NETWORK_DISCONNECTED:
+                            self._onDeviceError("Media element emitted OnNetworkDisconnected");
                             break;
 
                         case self.PlayerEventCodes.AUTHENTICATION_FAILED:
-                            self._onDeviceError("Authentication failed");
+                            self._onDeviceError("Media element emitted OnAuthenticationFailed");
                             break;
 
                         case self.PlayerEventCodes.RENDER_ERROR:
-                            self._onDeviceError("Render failed");
+                            self._onDeviceError("Media element emitted OnRenderError");
                             break;
 
                         case self.PlayerEventCodes.STREAM_NOT_FOUND:
-                            self._onDeviceError("Stream not found");
+                            self._onDeviceError("Media element emitted OnStreamNotFound");
                             break;
                     }
                 };
@@ -607,29 +649,33 @@ require.def(
             },
 
             _unregisterEventHandlers: function() {
+                this._playerPlugin.OnEvent = undefined;
                 window.removeEventListener('hide', this._onWindowHide, false);
                 window.removeEventListener('unload', this._onWindowHide, false);
             },
 
             _wipe: function () {
                 this._stopPlayer();
+                this._closePlugin();
+                this._unregisterEventHandlers();
                 this._type = undefined;
                 this._source = undefined;
                 this._mimeType = undefined;
                 this._currentTime = undefined;
                 this._range = undefined;
                 this._deferSeekingTo = null;
+                this._nextSeekingTo = null;
                 this._tryingToPause = false;
                 this._currentTimeKnown = false;
-                this._unregisterEventHandlers();
-                this._targetSeekTime = undefined;
+                this._updatingTime = false;
+                this._lastWindowRanged = false;
             },
 
             _seekTo: function(seconds) {
                 var offset = seconds - this.getCurrentTime();
                 var success = this._jump(offset);
 
-                if (success) {
+                if (success === 1) {
                     this._currentTime = seconds;
                 }
 
@@ -638,23 +684,17 @@ require.def(
 
             _seekToWithFailureStateTransition: function(seconds) {
                 var success = this._seekTo(seconds);
-                if (!success) {
+                if (success !== 1) {
                     this._toPlaying();
                 }
             },
 
             _jump: function (offsetSeconds) {
-                offsetSeconds = Math.floor(offsetSeconds);
-
                 if (offsetSeconds > 0) {
-                    this.logger.info('Calling this.playerPlugin.Execute("JumpForward", ' + offsetSeconds + ')');
                     var result = this._playerPlugin.Execute("JumpForward", offsetSeconds);
-                    this.logger.info('"JumpForward" responded with ' + result);
                     return result;
                 } else {
-                    this.logger.info('Calling this.playerPlugin.Execute("JumpBackward", ' + Math.abs(offsetSeconds) + ')');
                     var result = this._playerPlugin.Execute("JumpBackward", Math.abs(offsetSeconds));
-                    this.logger.info('"JumpBackward" responded with ' + result);
                     return result;
                 }
             },
@@ -663,10 +703,28 @@ require.def(
                 var mime = this._mimeType.toLowerCase();
                 return mime === "application/vnd.apple.mpegurl" || mime === "application/x-mpegurl";
             },
+            
+            _isCurrentTimeInRangeTolerance: function (seconds) {
+                if (seconds > this._range.end + this.RANGE_UPDATE_TOLERANCE) {
+                    return false;
+                } else if (seconds < this._range.start - this.RANGE_UPDATE_TOLERANCE) {
+                    return false;
+                } else {
+                    return true;
+                }
+            },
+            
+            _isInitialBufferingFinished: function () {
+                if (this._currentTime === undefined || this._currentTime === 0) {
+                    return false;
+                } else {
+                    return true;
+                }
+            },
 
             _reportError: function(errorMessage) {
                 RuntimeContext.getDevice().getLogger().error(errorMessage);
-                this._emitEvent(MediaPlayer.EVENT.ERROR);
+                this._emitEvent(MediaPlayer.EVENT.ERROR, {'errorMessage': errorMessage});
             },
 
             _toStopped: function () {
@@ -708,15 +766,6 @@ require.def(
                 throw "ApiError: " + errorMessage;
             },
 
-            _setDisplayFullScreenForVideo: function() {
-                if (this._type === MediaPlayer.TYPE.VIDEO) {
-                    var dimensions = RuntimeContext.getDevice().getScreenSize();
-                    this.logger.info('Calling this.playerPlugin.SetDisplayArea');
-                    var result = this._playerPlugin.SetDisplayArea(0, 0, dimensions.width, dimensions.height);
-                    this.logger.info('"SetDisplayArea" responded with ' + result);
-                }
-            },
-
             _isSuccessCode: function(code) {
                 var samsung2010ErrorCode = -1;
                 return code && code !== samsung2010ErrorCode;
@@ -724,10 +773,13 @@ require.def(
 
             /**
              * @constant {Number} Time (in seconds) compared to current time within which seeking has no effect.
-             * On a sample device (Samsung FoxP 2013), seeking by two seconds worked 90% of the time, but seeking
-             * by 2.5 seconds was always seen to work.
+             * Jumping to time lower than 3s causes error in PlayFrom60 on HLS live - player jumps to previous chunk.
+             * Value set to 4s to be ahead of potential wrong player jumps.
              */
-            CURRENT_TIME_TOLERANCE: 2.5
+            CURRENT_TIME_TOLERANCE: 4,
+            CLAMP_OFFSET_FROM_END_OF_LIVE_RANGE: 10,
+            RANGE_UPDATE_TOLERANCE: 8,
+            RANGE_END_TOLERANCE: 100
         });
 
         var instance = new Player();

--- a/static/script/devices/mediaplayer/samsung_streaming.js
+++ b/static/script/devices/mediaplayer/samsung_streaming.js
@@ -73,8 +73,8 @@ require.def(
             * @inheritDoc
             */
             setSource: function (mediaType, url, mimeType) {
+                this._logger = RuntimeContext.getDevice().getLogger();
                 if (this.getState() === MediaPlayer.STATE.EMPTY) {
-                    this._logger = RuntimeContext.getDevice().getLogger();
                     this._type = mediaType;
                     this._source = url;
                     this._mimeType = mimeType;

--- a/static/script/devices/mediaplayer/samsung_streaming.js
+++ b/static/script/devices/mediaplayer/samsung_streaming.js
@@ -722,6 +722,9 @@ require.def(
             },
 
             _toPlaying: function () {
+                if (this._isHlsMimeType() && this._isLiveMedia() && !this._updatingTime) {
+                    this._updateRange();
+                }
                 this._state = MediaPlayer.STATE.PLAYING;
                 this._emitEvent(MediaPlayer.EVENT.PLAYING);
             },


### PR DESCRIPTION
player module: static/script/devices/mediaplayer/samsung_streaming.js
- use Player Emp for MP4 and HLS VOD
- use new StreamingPlayer Emp for HLS Live
- add correct postfix to HLS and HLS live only
- reopen correct plugin every time on setSource()
- remove buffer methods in _initPlayer() - they are necessary only for UHD playback
- new error handling for InitPlayer failure
- new scenario for updating live range (for better performance)
    1. call range on stream start
    2. update range manually every 8 seconds (chunk length) + condition check if range was already updated on current time in seconds or less than chunk length time ago
    3. call range before JumpForward/Backward (synchronise with server) + check if API was not called less than chunk length time ago
    4. call range if current time is out of range
- [workaround] in CURRENT_PLAYBACK_TIME for PTS jump - if new current time is far ahead from previous current time then jump back to previous current time
- remove all logs
- remove method to set display area - for fullscreen playback calling this method is not necessary
- fix restarting VOD playback from COMPLETE state
- changed scenario for playFrom while in BUFFERING state - required due to different event handling in SEF compared to old Device API, which resulted in BUFFERING state not changing to PLAYING (defect was reproducing during my December visit to BBC office)
- extented CURRENT_TIME_TOLERANCE to 4s
- beginPlaybackFrom(0) in HLS live clamped to 1s to avoid spoiler defect
- changed error handling to match unit tests
- close SEF plugin on _wipe()


unit tests:  static/script-tests/tests/devices/mediaplayer/samsung_streaming.js
- all tests ported from the old Device API player static/script-tests/tests/devices/mediaplayer/samsung_maple.js
- new tests detecting player switching
- new tests for GetPlayingRange() in HLS Live scenario