### PR TITLE
Handle all system events as specified in WebMAF

### DIFF
--- a/static/script/devices/ps3base.js
+++ b/static/script/devices/ps3base.js
@@ -78,6 +78,29 @@ define(
                     case 'contentAvailable':
                     case 'playerStatusChange':
                     case 'getContentParameters':
+                    case 'externalParameter':
+                    case 'contentAvailable':
+                    case 'applicationStatusChange':
+                    case 'networkStatusChange':
+                    case 'playerStatusChange':
+                    case 'playerSubtitle':
+                    case 'playerStreamingError':
+                    case 'playerError':
+                    case 'playerMessage':
+                    case 'externalParameter':
+                    case 'shutdownNotification':
+                    case 'fbAccessToken':
+                    case 'psnActivityFeedResponse':
+                    case 'onOskClose':
+                    case 'touchPanelEvent':
+                    case 'psnCommerceProductDataResponse':
+                    case 'psnCommerceCategoryDataResponse':
+                    case 'psnEntitlementList':
+                    case 'psnCommercePurchaseProductResponse':
+                    case 'psnCommerceCheckoutResponse':
+                    case 'lowBatteryNotification':
+                    case 'npAuthCodeResponse':
+                    case 'resetVrPosition':
                         // multiple event listeners may be listening for these events
                         for(var i = 0; i < callbacks.length; i++) {
                             callbacks[i](data);

--- a/static/script/devices/ps3base.js
+++ b/static/script/devices/ps3base.js
@@ -78,7 +78,6 @@ define(
                     case 'contentAvailable':
                     case 'playerStatusChange':
                     case 'getContentParameters':
-                    case 'externalParameter':
                     case 'contentAvailable':
                     case 'applicationStatusChange':
                     case 'networkStatusChange':

--- a/static/script/devices/ps3base.js
+++ b/static/script/devices/ps3base.js
@@ -74,9 +74,6 @@ define(
                 var callbacks = this._nativeCallbacks[data.command];
                 if(callbacks && callbacks.length > 0) {
                     switch(data.command) {
-                    case 'networkStatusChange':
-                    case 'contentAvailable':
-                    case 'playerStatusChange':
                     case 'getContentParameters':
                     case 'contentAvailable':
                     case 'applicationStatusChange':


### PR DESCRIPTION
Related to: https://jira.dev.bbc.co.uk/browse/IPLAYERTVV1-5170 (Handle deeplink events)

List of system events taken from WebMAF documentation v0.35 (Last edit: 26/08/2016 by _David Uberti_ Added information about SettingPassphrase setting.)

All these system events are sent to the window function *accessfunction*, as registered by [playstation3 page strategy](https://github.com/bbc/tal-page-strategies/blob/master/playstation3/body). The switch statement differentiates between asynchronous callbacks as requests for information, and registered event handlers based on command/key name. The seperation of concerns could be better, but in keeping with the current implementation, making exceptions for the known system events is probably simpler.