### PR TITLE
Handle empty response

### DIFF
--- a/static/script-tests/tests/devices/device.js
+++ b/static/script-tests/tests/devices/device.js
@@ -789,6 +789,25 @@ require(
         });
     };
 
+    this.DefaultNetworkTest.prototype.testExecuteCrossDomainGetDoesNotErrorOnEmptyResponseFromLoadUrlWhenCorsIsSupported = function(queue) {
+        expectAsserts(3);
+
+        queuedApplicationInit(queue, 'lib/mockapplication', ['antie/devices/browserdevice'], function(application, BrowserDevice) {
+            var device = new BrowserDevice({'networking': { 'supportsCORS': true }});
+            var testUrl = 'http://test';
+            var successSpy = this.sandbox.stub();
+
+            device.executeCrossDomainGet(testUrl, {onSuccess: successSpy});
+
+            assertEquals(1, this.requests.length);
+
+            this.requests[0].respond(204, { 'Content-Type': 'text/plain' }, '');
+
+            assert(successSpy.calledOnce);
+            assert(successSpy.calledWith({}));
+        });
+    };
+
     this.DefaultNetworkTest.prototype.testExecuteCrossDomainGetHandlesErrorFromLoadUrlWhenCorsIsSupported = function(queue) {
         expectAsserts(2);
 

--- a/static/script-tests/tests/sanitisers/whitelisted.js
+++ b/static/script-tests/tests/sanitisers/whitelisted.js
@@ -119,10 +119,10 @@ require(
             });
         });
 
-        describe('Mixed Type Sanitzation', function() {
+        describe('Mixed Type Sanitisation', function() {
 
             var el = document.createElement('div');
-            it ('returns mixed string with sanitsation implemented', function () {
+            it ('returns mixed string with sanitisation implemented', function () {
                 var string = '<div><h1>Title</h1><ul><li>list 1</li><li><script>nastiness</script>OK</li></ul></div>',
                     result = '<h1>Title</h1><ul><li>list 1</li><li>OK</li></ul>',
                     sanitiser = new Sanitiser(string);

--- a/static/script/devices/device.js
+++ b/static/script/devices/device.js
@@ -821,7 +821,8 @@ define(
                 if (configSupportsCORS(this.getConfig())) {
                     modifiedOpts = {
                         onLoad: function (jsonResponse) {
-                            opts.onSuccess(self.decodeJson(jsonResponse));
+                            var json = jsonResponse ? self.decodeJson(jsonResponse) : {};
+                            opts.onSuccess(json);
                         },
                         onError: opts.onError
                     };


### PR DESCRIPTION
TAL tries to parse JSON from any response, including an empty response, e.g. a HTTP 204. This causes errors.

If applied, this change will return an empty object to the callback, without calling JSON.parse, for an empty, but successful, response.