### PR TITLE
JSDoc inconsistencies

### DIFF
--- a/static/script/widgets/carousel/carouselcore.js
+++ b/static/script/widgets/carousel/carouselcore.js
@@ -94,7 +94,7 @@ define(
 
             /**
              * Manually sets lengths of elements for movement calculations - useful for elements which change size while moving.
-             * @param lengths {number} | {Array} If provided with a number all lengths will be set equal to this number
+             * @param {(Number|Number[])} lengths If provided with a number all lengths will be set equal to this number
              * If provided with an array, the lengths will be set with the corresponding widgets (so the first number will be used
              * for the first widget's length, etc..)
              * Note only currently working with non-wrapping strips.
@@ -107,7 +107,7 @@ define(
              * Manually sets length of te Mask. Normally this is measured from the DOM, but if the first alignment happens before
              * the DOM is ready, then culling strips may not get populated. In this case, call this first with the size in pixels of
              * the mask.
-             * @param length {number} The length in pixels to use in Mask calculations.
+             * @param {Number} length The length in pixels to use in Mask calculations.
              */
             setMaskLength: function setMaskLength (length) {
                 this._mask.setLength(length);
@@ -115,7 +115,8 @@ define(
 
             /**
              * Removes a widget from the carousel
-             * @param {antie.widgets.Widget} widget. Widget to remove from the DOM
+             * @param {antie.widgets.Widget} widget Widget to remove from the DOM      
+             * @param {Boolean} [retainElement=false] Whether to keep the widget's output element in the DOM after removing widget  
              */
             remove: function remove (widget, retainElement) {
                 if (this.hasChildWidget(widget.id)) {

--- a/static/script/widgets/carousel/strips/widgetstrip.js
+++ b/static/script/widgets/carousel/strips/widgetstrip.js
@@ -62,8 +62,8 @@ define(
 
             /**
              * Removes a widget from the strip
-             * @param {antie.widgets.Widget} widget. Widget to remove from the strip
-             * @param {Boolean} [retainElement=false] whether to keep the widget's output element in the DOM after removing widget
+             * @param {antie.widgets.Widget} widget Widget to remove from the strip
+             * @param {Boolean} [retainElement=false] Whether to keep the widget's output element in the DOM after removing widget
              */
             remove: function remove (widget, retainElement) {
                 var i, widgets;

--- a/static/script/widgets/carousel/strips/wrappingstrip.js
+++ b/static/script/widgets/carousel/strips/wrappingstrip.js
@@ -86,7 +86,8 @@ define(
 
             /**
              * Removes a widget from the strip
-             * @param {antie.widgets.Widget} widget. Widget to remove from the strip
+             * @param {antie.widgets.Widget} widget Widget to remove from the strip
+             * @param {Boolean} [retainElement=false] Whether to keep the widget's output element in the DOM after removing widget
              */
             remove: function remove (widget, retainElement) {
                 remove.base.call(this, widget, retainElement);


### PR DESCRIPTION
Hey,

I fixed some issues concerning JSDoc comments, especially the one regarding [multiple types](http://usejsdoc.org/tags-param.html#multiple-types-and-repeatable-parameters). Additionally I fixed some inconsistencies in the way capitalization of parameter types was handled (I know JSDoc is case-insensitive, but in my opinion it's better to stick to one convention per codebase).

Cheers