### PR TITLE
Deprecate Device JSON methods in favour of using JSON

### DIFF
--- a/static/script/devices/data/json2.js
+++ b/static/script/devices/data/json2.js
@@ -1,5 +1,6 @@
 /*
  * @fileOverview Requirejs modifier to use J Crockford's JSON2 implementation.
+ * @deprecated since version 8.1.0, use a JSON polyfill if needed.
  */
 
 define(

--- a/static/script/devices/data/nativejson.js
+++ b/static/script/devices/data/nativejson.js
@@ -2,6 +2,7 @@
  * @fileOverview Requirejs modifier to use native JSON decoding/encoding if supported by the browser
  * @preserve Copyright (c) 2013-present British Broadcasting Corporation. All rights reserved.
  * @license See https://github.com/fmtvp/tal/blob/master/LICENSE for full licence
+ * @deprecated since version 8.1.0, use JSON directly.
  */
 
 define(

--- a/static/script/devices/device.js
+++ b/static/script/devices/device.js
@@ -497,12 +497,14 @@ define(
             },
             /**
              * Encodes an object as JSON.
+             * @deprecated since version 8.1.0, use JSON.stringify
              * @param {object} obj Object to encode.
              */
             encodeJson: function encodeJson (/*obj*/) {
             },
             /**
              * Decodes JSON.
+             * @deprecated since version 8.1.0, use JSON.parse
              * @param {String} json JSON to decode.
              */
             decodeJson: function decodeJson (/*json*/) {

--- a/static/script/devices/device.js
+++ b/static/script/devices/device.js
@@ -817,13 +817,12 @@ define(
              * for JSON-P call. Default: callback
              */
             executeCrossDomainGet: function executeCrossDomainGet (url, opts, jsonpOptions) {
-                var self, callbackKey, callbackQuery, modifiedOpts;
-                self = this;
+                var callbackKey, callbackQuery, modifiedOpts;
                 jsonpOptions = jsonpOptions || {};
                 if (configSupportsCORS(this.getConfig())) {
                     modifiedOpts = {
                         onLoad: function onLoad (jsonResponse) {
-                            var json = jsonResponse ? self.decodeJson(jsonResponse) : {};
+                            var json = jsonResponse ? JSON.parse(jsonResponse) : {};
                             opts.onSuccess(json);
                         },
                         onError: opts.onError
@@ -867,7 +866,7 @@ define(
              */
             executeCrossDomainPost: function executeCrossDomainPost (url, data, opts) {
                 var payload, modifiedOpts, formData;
-                payload = this.encodeJson(data);
+                payload = JSON.stringify(data);
                 if (configSupportsCORS(this.getConfig())) {
                     modifiedOpts = {
                         onLoad: opts.onLoad,

--- a/static/script/devices/logging/xhr.js
+++ b/static/script/devices/logging/xhr.js
@@ -56,9 +56,7 @@ define(
         function xhrPost(url, opts, messageObject) {
 
             var http = new XMLHttpRequest();
-
-            var device = RuntimeContext.getCurrentApplication().getDevice();
-            var jsonMessage = device.encodeJson( messageObject );
+            var jsonMessage = JSON.stringify(messageObject);
 
             http.open('POST', url, true);
 

--- a/static/script/devices/logging/xhr.js
+++ b/static/script/devices/logging/xhr.js
@@ -12,7 +12,7 @@ define(
         'antie/runtimecontext',
         'antie/devices/device'
     ],
-    function( Module, RuntimeContext, Device) {
+    function(Module, RuntimeContext, Device) {
         'use strict';
 
         function zeroFill(number, width) {

--- a/static/script/devices/ps3base.js
+++ b/static/script/devices/ps3base.js
@@ -51,7 +51,7 @@ define(
                 this._endtag = endtag;
             },
             nativeCallback: function nativeCallback (json) {
-                var data = this.decodeJson(json);
+                var data = JSON.parse(json);
 
                 if(enableDebugging) {
                     if(!debug) {

--- a/static/script/devices/storage/cookie.js
+++ b/static/script/devices/storage/cookie.js
@@ -88,7 +88,9 @@ define(
                 var cookie = readCookie(namespace);
 
                 if(cookie) {
-                    this._valueCache = Device.prototype.decodeJson(cookie);
+                    try {
+                        this._valueCache = JSON.parse(cookie);
+                    } catch (e) { /* couldn't parse cookie, just ignore it */ }
                     if(this._valueCache) {
                         this._save();
                     } else {

--- a/static/script/devices/storage/cookie.js
+++ b/static/script/devices/storage/cookie.js
@@ -119,7 +119,7 @@ define(
                 if(this.isEmpty()) {
                     eraseCookie(this._namespace, this._opts);
                 } else {
-                    var json = Device.prototype.encodeJson(this._valueCache);
+                    var json = JSON.stringify(this._valueCache);
                     createCookie(this._namespace, json, undefined, this._opts);
                 }
             }

--- a/static/script/devices/storage/xboxpls.js
+++ b/static/script/devices/storage/xboxpls.js
@@ -24,7 +24,7 @@ define(
             getItem: function getItem (key) {
                 if (this._storage.hasKey(key)) {
                     var value = this._storage.lookup(key);
-                    var jsonifiedValue = Device.prototype.decodeJson(value);
+                    var jsonifiedValue = JSON.parse(value);
 
                     if (jsonifiedValue === null) {
                         return undefined;
@@ -36,8 +36,7 @@ define(
             },
 
             setItem: function setItem (key, value) {
-                var stringifiedValue = Device.prototype.encodeJson(value);
-                this._storage.insert(key, stringifiedValue);
+                this._storage.insert(key, JSON.stringify(value));
             },
 
             removeItem: function removeItem (key) {


### PR DESCRIPTION
JSON should be available on all devices correctly running es5 (been a requirement of TAL since 5.0.0) and is easily polyfillable on devices where it is not present.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON