### PR TITLE
Fix lint script

### DIFF
--- a/static/script-tests/tests/devices/mediaplayer/html5commontests.js
+++ b/static/script-tests/tests/devices/mediaplayer/html5commontests.js
@@ -1559,7 +1559,7 @@ window.commonTests.mediaPlayer.html5.mixinTests = function (testCase, mediaPlaye
             clearEvents(self);
             fireSentinels(self);
 
-            assertNoEvents(self)
+            assertNoEvents(self);
             assertState(self, MediaPlayer.STATE.BUFFERING);
         });
     };


### PR DESCRIPTION
Adds a missing semicolon, which caused the eslint task to fail.