### PR TITLE
New Android exit strategy

### DIFF
--- a/static/script/devices/exit/android.js
+++ b/static/script/devices/exit/android.js
@@ -1,0 +1,24 @@
+/**
+ * @fileOverview Requirejs module for android exit strategy.
+ * Uses a callback into 'Android' namespace for android WebView (or similar)
+ * environment, to let Java-native application code clean up window/activity.
+ * @preserve Copyright (c) 2013-present British Broadcasting Corporation. All rights reserved.
+ * @license See https://github.com/bbc/tal/blob/master/LICENSE for full licence
+ */
+
+define(
+    'antie/devices/exit/android',
+    ['antie/devices/browserdevice'],
+    function(Device) {
+        'use strict';
+
+        /**
+         * Exits the application by invoking window.open() on the current window,
+         * then window.close().
+         */
+        Device.prototype.exit = function() {
+            /* Call into named 'Android' namespace to have Java handle exit. */
+            Android.nativeApplicationExit();
+        };
+    }
+);


### PR DESCRIPTION
To support modern chromium web implementations (webview, crosswalk, etc.), the existing closewindow and openclosewindow strategies no longer work.

This uses the "Android" namespace, and "nativeApplicationExit()" callback/fn, to allow an android application's Java side code to handle the request to exit, as it needs to in Java code.