### PR TITLE
Added empty options object to show, hide and moveTo functions

### DIFF
--- a/static/script/widgets/widget.js
+++ b/static/script/widgets/widget.js
@@ -272,6 +272,7 @@ define(
              * @returns Boolean true if animation was called, otherwise false
              */
             show : function(options) {
+                options = options || {};
                 if (this.outputElement) {
                     options.el = this.outputElement;
                     var device = this.getCurrentApplication().getDevice();
@@ -291,6 +292,7 @@ define(
              * @returns Boolean true if animation was called, otherwise false
              */
             hide : function(options) {
+                options = options || {};
                 if (this.outputElement) {
                     options.el = this.outputElement;
                     var device = this.getCurrentApplication().getDevice();
@@ -310,6 +312,7 @@ define(
              * @returns Boolean true if animation was called, otherwise false
              */
             moveTo : function(options) {
+                options = options || {};
                 if (this.outputElement) {
                     options.el = this.outputElement;
                     var device = this.getCurrentApplication().getDevice();


### PR DESCRIPTION
So that you can omit the empty object argument when calling the functions.