### PR TITLE
fix exec order in fireEvent

### DIFF
--- a/static/script/widgets/widget.js
+++ b/static/script/widgets/widget.js
@@ -142,7 +142,7 @@ define(
 
                 listener = listeners.indexOf(func);
                 if (~listener) {
-                    listeners.splice(listener, 1);
+                  listeners[listener] = null;
                 }
             },
             /**
@@ -155,16 +155,21 @@ define(
             fireEvent: function fireEvent (ev) {
                 var listeners = this._eventListeners[ev.type];
                 if (listeners) {
+                  var filtered = [];
                     for (var func in listeners) {
                         if(listeners.hasOwnProperty(func)) {
                             try {
                                 listeners[func](ev);
+                                if (listeners[func]) {
+                                  filtered[func] = listeners[func]
+                                }
                             } catch (exception) {
                                 var logger = this.getCurrentApplication().getDevice().getLogger();
                                 logger.error('Error in ' + ev.type + ' event listener on widget ' + this.id + ': ' + exception.message, exception, listeners[func]);
                             }
                         }
-                    }
+                    };
+                    this._eventListeners[ev.type] = filtered
                 }
             },
             /**


### PR DESCRIPTION
This fix solves the problem with execution of listeners (as below)

```
this.addEventListener("aftershow", function run() {
  console.log("1st listener!")
});

this.addEventListener("aftershow", function run2() {
  console.log("2nd listener!")
  console.log("breaking listeners chain...")
  self.removeEventListener("aftershow", run2);
});

this.addEventListener("aftershow", function run3() {
  console.log("3rd listener misssed now, will be started only at the next 'aftershow'")
});

this.addEventListener("aftershow", function run4() {
  console.log("4th listener!")
});
```